### PR TITLE
Added short_paths option to llvm conan recipe.

### DIFF
--- a/contrib/conan/recipes/llvm/conanfile.py
+++ b/contrib/conan/recipes/llvm/conanfile.py
@@ -4,6 +4,7 @@ llvm_common = python_requires('llvm-common/0.0.0@orbitdeps/stable')
 class LLVMConan(llvm_common.LLVMComponentPackage):
     name = "llvm"
     version = llvm_common.LLVMComponentPackage.version
+    short_paths = True
 
     custom_cmake_options = {
         'LLVM_BUILD_TOOLS': True


### PR DESCRIPTION
With the RelWithDebInfo build configuration,
llvm's build paths get too long to fit into
Windows 255 character limit. That's why enabling
short_paths = True is necessary for llvm.

### `short_paths`
This option instructs conan to place the buildtree under `%SYSTEMDRIVE%:\.conan`
instead of `%SYSTEMDRIVE%:\Users\%USER%\.conan`. This shortens the absolute path.

The consumption of the resulting package is not affected by this.