### PR TITLE
Improved Docker-based dependency build workflow

### DIFF
--- a/contrib/conan/docker/Dockerfile.clang7
+++ b/contrib/conan/docker/Dockerfile.clang7
@@ -1,0 +1,10 @@
+FROM conanio/clang7:latest
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+    libglu1-mesa-dev \
+    mesa-common-dev \
+    libxmu-dev \
+    libxi-dev \
+    qt5-default \
+    jq 

--- a/contrib/conan/docker/Dockerfile.clang8
+++ b/contrib/conan/docker/Dockerfile.clang8
@@ -1,0 +1,10 @@
+FROM conanio/clang8:latest
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+    libglu1-mesa-dev \
+    mesa-common-dev \
+    libxmu-dev \
+    libxi-dev \
+    qt5-default \
+    jq 

--- a/contrib/conan/docker/Dockerfile.clang9
+++ b/contrib/conan/docker/Dockerfile.clang9
@@ -1,0 +1,10 @@
+FROM conanio/clang9:latest
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+    libglu1-mesa-dev \
+    mesa-common-dev \
+    libxmu-dev \
+    libxi-dev \
+    qt5-default \
+    jq 

--- a/contrib/conan/docker/Dockerfile.gcc8
+++ b/contrib/conan/docker/Dockerfile.gcc8
@@ -1,0 +1,10 @@
+FROM conanio/gcc8:latest
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+    libglu1-mesa-dev \
+    mesa-common-dev \
+    libxmu-dev \
+    libxi-dev \
+    qt5-default \
+    jq 

--- a/contrib/conan/docker/Dockerfile.gcc9
+++ b/contrib/conan/docker/Dockerfile.gcc9
@@ -1,0 +1,10 @@
+FROM conanio/gcc9:latest
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+    libglu1-mesa-dev \
+    mesa-common-dev \
+    libxmu-dev \
+    libxi-dev \
+    qt5-default \
+    jq 


### PR DESCRIPTION
In the previous version of the dependency build script,
system dependencies (debian packages) had to be installed
over and over again.

This change introduces dedicated docker containers which have
theses debian packages already installed.

The Dockerfiles which are needed to create these containers are included as well.

Additionally the docker containers are available on docker hub under my
personal account (https://hub.docker.com/r/hebecker/). I'm more than willing to push
them somewhere else but right now I wasn't sure if it is worth it to take the effort and
create an organizational account on docker-hub. I suggest to postpone the question
until the CI is properly set up and we know how to integrate with that.