### PR TITLE
Move server session data out of OrbitApp

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(
          Introspection.h
          LinuxCallstackEvent.h
          LinuxSymbol.h
+         LinuxTracingSession.h
          Log.h
          LogInterface.h
          MemoryTracker.h
@@ -87,6 +88,7 @@ target_sources(
           Injection.cpp
           Introspection.cpp
           LinuxCallstackEvent.cpp
+          LinuxTracingSession.cpp
           Log.cpp
           LogInterface.cpp
           MemoryTracker.cpp
@@ -207,6 +209,7 @@ add_executable(OrbitCoreTests)
 target_sources(OrbitCoreTests PRIVATE
     RingBufferTest.cpp
     StringManagerTest.cpp
+    LinuxTracingSessionTests.cpp
 )
 
 if(NOT WIN32)

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -196,10 +196,12 @@ bool Capture::StartCapture(LinuxTracingSession* session) {
     Capture::GSamplingProfiler->StartCapture();
   }
 
-  GCoreApp->SendToUiNow(L"startcapture");
+  if (GCoreApp != nullptr) {
+    GCoreApp->SendToUiNow(L"startcapture");
 
-  if (GSelectedFunctionsMap.size() > 0) {
-    GCoreApp->SendToUiNow(L"gotolive");
+    if (GSelectedFunctionsMap.size() > 0) {
+      GCoreApp->SendToUiNow(L"gotolive");
+    }
   }
 
   return true;
@@ -605,7 +607,7 @@ std::shared_ptr<CallStack> Capture::GetCallstack(CallstackID a_ID) {
 
 //-----------------------------------------------------------------------------
 void Capture::CheckForUnrealSupport() {
-  GUnrealSupported =
+  GUnrealSupported = GCoreApp != nullptr &&
       GCoreApp->GetUnrealSupportEnabled() && GOrbitUnreal.HasFnameInfo();
 }
 

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <string>
 
+#include "LinuxTracingSession.h"
 #include "CallstackTypes.h"
 #include "OrbitType.h"
 #include "Threading.h"
@@ -22,9 +23,8 @@ struct Capture {
   static bool Connect();
   static bool InjectRemote();
   static void SetTargetProcess(const std::shared_ptr<Process>& a_Process);
-  static bool StartCapture();
+  static bool StartCapture(LinuxTracingSession* session);
   static void StopCapture();
-  static void ToggleRecording();
   static void ClearCaptureData();
   static void PreFunctionHooks();
   static void SendFunctionHooks();
@@ -84,7 +84,7 @@ struct Capture {
 
   static Timer GTestTimer;
   static ULONG64 GMainFrameFunction;
-  static ULONG64 GNumContextSwitches;
+  static uint64_t GNumContextSwitches;
   static ULONG64 GNumLinuxEvents;
   static ULONG64 GNumProfileEvents;
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
@@ -92,8 +92,8 @@ struct Capture {
   static std::shared_ptr<Session> GSessionPresets;
   static std::shared_ptr<CallStack> GSelectedCallstack;
   static void (*GClearCaptureDataFunc)();
-  static std::map<ULONG64, Function*> GSelectedFunctionsMap;
-  static std::map<ULONG64, Function*> GVisibleFunctionsMap;
+  static std::map<uint64_t, Function*> GSelectedFunctionsMap;
+  static std::map<uint64_t, Function*> GVisibleFunctionsMap;
   static std::unordered_map<ULONG64, ULONG64> GFunctionCountMap;
   static std::vector<ULONG64> GSelectedAddressesByType[Function::NUM_TYPES];
   static std::unordered_map<DWORD64, std::shared_ptr<CallStack> > GCallstacks;

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -44,15 +44,12 @@ class CoreApp {
   virtual void AddSymbol(uint64_t /*a_Address*/,
                          const std::string& /*a_Module*/,
                          const std::string& /*a_Name*/) {}
-  virtual void AddKeyAndString(uint64_t key, const std::string_view str) {}
+  virtual void AddKeyAndString(uint64_t key, std::string_view str) {}
   virtual const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >*
   GetRules() {
     return nullptr;
   }
   virtual void RefreshCaptureView() {}
-
-  virtual void StartRemoteCaptureBufferingThread() {}
-  virtual void StopRemoteCaptureBufferingThread() {}
 
   std::vector<std::string> m_SymbolLocations;
 };

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -10,6 +10,8 @@
 #include "Serialization.h"
 
 #ifdef __linux
+#include "EventTracer.h"
+#include "LinuxTracingHandler.h"
 EventTracer GEventTracer;
 #endif
 
@@ -78,13 +80,13 @@ ORBIT_SERIALIZE(CallstackEvent, 0) {
 #ifdef __linux
 
 //-----------------------------------------------------------------------------
-void EventTracer::Start(uint32_t a_PID) {
+void EventTracer::Start(uint32_t a_PID, LinuxTracingSession* session) {
   Capture::NewSamplingProfiler();
   Capture::GSamplingProfiler->StartCapture();
 
   m_LinuxTracer = std::make_shared<LinuxTracingHandler>(
-      GCoreApp, Capture::GTargetProcess.get(), &Capture::GSelectedFunctionsMap,
-      &Capture::GNumContextSwitches);
+      Capture::GSamplingProfiler.get(), session, Capture::GTargetProcess.get(),
+      &Capture::GSelectedFunctionsMap, &Capture::GNumContextSwitches);
   m_LinuxTracer->Start();
 }
 

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -11,7 +11,6 @@
 #include "SerializationMacros.h"
 
 #ifdef __linux
-#include "LinuxTracingHandler.h"
 #include "LinuxUtils.h"
 #endif
 
@@ -84,17 +83,3 @@ class EventBuffer {
   std::atomic<long long> m_MinTime;
 };
 
-#ifdef __linux
-class EventTracer {
- public:
-  EventBuffer& GetEventBuffer() { return m_EventBuffer; }
-  EventBuffer m_EventBuffer;
-  void Start(uint32_t a_PID);
-  void Stop();
-
- private:
-  std::shared_ptr<LinuxTracingHandler> m_LinuxTracer;
-};
-
-extern EventTracer GEventTracer;
-#endif

--- a/OrbitCore/EventTracer.h
+++ b/OrbitCore/EventTracer.h
@@ -39,4 +39,20 @@ class EventTracer {
 
 extern EventTracer GEventTracer;
 
+#elif defined(__linux)
+#include "LinuxTracingHandler.h"
+
+class EventTracer {
+ public:
+  EventBuffer& GetEventBuffer() { return m_EventBuffer; }
+  EventBuffer m_EventBuffer;
+  void Start(uint32_t a_PID, LinuxTracingSession* session);
+  void Stop();
+
+ private:
+  // TODO: Fix circular dependencies in header files.
+  std::shared_ptr<class LinuxTracingHandler> m_LinuxTracer;
+};
+
+extern EventTracer GEventTracer;
 #endif

--- a/OrbitCore/Introspection.cpp
+++ b/OrbitCore/Introspection.cpp
@@ -5,9 +5,11 @@
 #include <memory>
 #include <vector>
 
-#include <OrbitBase/Tracing.h>
 #include "CoreApp.h"
+#include "OrbitBase/Tracing.h"
+#include "KeyAndString.h"
 #include "PrintVar.h"
+#include "TcpServer.h"
 #include "Utils.h"
 
 #ifdef _WIN32
@@ -26,6 +28,10 @@ namespace introspection {
 
 thread_local std::vector<Scope> scopes;
 
+Handler::Handler(std::shared_ptr<StringManager> string_manager,
+                 LinuxTracingSession* tracing_session)
+    : string_manager_(string_manager), tracing_session_(tracing_session) {}
+
 void Handler::Begin(const char* name) {
   scopes.emplace_back(Scope{Timer(), name});
   scopes.back().timer_.Start();
@@ -33,16 +39,33 @@ void Handler::Begin(const char* name) {
 
 void Handler::End() {
   Scope& scope = scopes.back();
+
   scope.timer_.Stop();
   scope.timer_.m_Type = Timer::INTROSPECTION;
   scope.timer_.m_Depth = scopes.size() - 1;
 
   uint64_t hash = StringHash(scope.name_);
-  GCoreApp->AddKeyAndString(hash, scope.name_);
+  SendKeyAndString(hash, scope.name_);
   scope.timer_.m_UserData[0] = hash;
 
-  GCoreApp->ProcessTimer(scope.timer_, scope.name_);
+  tracing_session_->RecordTimer(std::move(scope.timer_));
+
   scopes.pop_back();
+}
+
+void Handler::SendKeyAndString(uint64_t key, const std::string& str) {
+  KeyAndString key_and_string;
+  key_and_string.key = key;
+  key_and_string.str = str;
+  // TODO: This is not atomic, we might end up sending multiple keys
+  // maybe change it to AddIfDoesNotExists()
+  if (!string_manager_->Exists(key)) {
+    std::string message_data = SerializeObjectBinary(key_and_string);
+    // TODO: Remove networking from here.
+    GTcpServer->Send(Msg_KeyAndString, message_data.c_str(),
+                     message_data.size());
+    string_manager_->Add(key, str);
+  }
 }
 
 void Handler::Track(const char* name, int) {}

--- a/OrbitCore/Introspection.h
+++ b/OrbitCore/Introspection.h
@@ -1,8 +1,11 @@
 #ifndef ORBIT_CORE_INTROSPECTION_H_
 #define ORBIT_CORE_INTROSPECTION_H_
 
-#include <OrbitBase/Tracing.h>
+#include "OrbitBase/Tracing.h"
+
+#include "LinuxTracingSession.h"
 #include "ScopeTimer.h"
+#include "StringManager.h"
 
 #if ORBIT_TRACING_ENABLED
 
@@ -10,10 +13,20 @@ namespace orbit {
 namespace introspection {
 
 class Handler : public orbit::tracing::Handler {
+ public:
+  Handler(std::shared_ptr<StringManager> string_manager,
+          LinuxTracingSession* tracing_session);
+
   void Begin(const char* name) final;
   void End() final;
   void Track(const char* name, int) final;
   void Track(const char* name, float) final;
+
+ private:
+  void SendKeyAndString(uint64_t hash, const std::string& name);
+
+  std::shared_ptr<StringManager> string_manager_;
+  LinuxTracingSession* tracing_session_;
 };
 
 struct Scope {

--- a/OrbitCore/LinuxTracingSession.cpp
+++ b/OrbitCore/LinuxTracingSession.cpp
@@ -1,0 +1,94 @@
+#include "LinuxTracingSession.h"
+
+#include <utility>
+
+void LinuxTracingSession::RecordContextSwitch(ContextSwitch&& context_switch) {
+  absl::MutexLock lock(&context_switch_buffer_mutex_);
+  context_switch_buffer_.push_back(std::move(context_switch));
+}
+
+void LinuxTracingSession::RecordTimer(Timer&& timer) {
+  absl::MutexLock lock(&timer_buffer_mutex_);
+  timer_buffer_.push_back(std::move(timer));
+}
+
+void LinuxTracingSession::RecordCallstack(LinuxCallstackEvent&& event) {
+  absl::MutexLock lock(&callstack_buffer_mutex_);
+  callstack_buffer_.push_back(std::move(event));
+}
+
+void LinuxTracingSession::RecordHashedCallstack(
+    CallstackEvent&& hashed_call_stack) {
+  absl::MutexLock lock(&hashed_callstack_buffer_mutex_);
+  hashed_callstack_buffer_.push_back(std::move(hashed_call_stack));
+}
+
+bool LinuxTracingSession::ReadAllContextSwitches(
+    std::vector<ContextSwitch>* buffer) {
+  absl::MutexLock lock(&context_switch_buffer_mutex_);
+  if (context_switch_buffer_.empty()) {
+    return false;
+  }
+
+  *buffer = std::move(context_switch_buffer_);
+  context_switch_buffer_.clear();
+  return true;
+}
+
+bool LinuxTracingSession::ReadAllTimers(std::vector<Timer>* buffer) {
+  absl::MutexLock lock(&timer_buffer_mutex_);
+  if (timer_buffer_.empty()) {
+    return false;
+  }
+
+  *buffer = std::move(timer_buffer_);
+  timer_buffer_.clear();
+  return true;
+}
+
+bool LinuxTracingSession::ReadAllCallstacks(
+    std::vector<LinuxCallstackEvent>* buffer) {
+  absl::MutexLock lock(&callstack_buffer_mutex_);
+  if (callstack_buffer_.empty()) {
+    return false;
+  }
+
+  *buffer = std::move(callstack_buffer_);
+  callstack_buffer_.clear();
+  return true;
+}
+
+bool LinuxTracingSession::ReadAllHashedCallstacks(
+    std::vector<CallstackEvent>* buffer) {
+  absl::MutexLock lock(&hashed_callstack_buffer_mutex_);
+  if (hashed_callstack_buffer_.empty()) {
+    return false;
+  }
+
+  *buffer = std::move(hashed_callstack_buffer_);
+  hashed_callstack_buffer_.clear();
+  return true;
+}
+
+void LinuxTracingSession::Reset() {
+  {
+    absl::MutexLock lock(&context_switch_buffer_mutex_);
+    context_switch_buffer_.clear();
+  }
+
+  {
+    absl::MutexLock lock(&timer_buffer_mutex_);
+    timer_buffer_.clear();
+  }
+
+  {
+    absl::MutexLock lock(&callstack_buffer_mutex_);
+    callstack_buffer_.clear();
+  }
+
+  {
+    absl::MutexLock lock(&hashed_callstack_buffer_mutex_);
+    hashed_callstack_buffer_.clear();
+  }
+}
+

--- a/OrbitCore/LinuxTracingSession.h
+++ b/OrbitCore/LinuxTracingSession.h
@@ -1,0 +1,49 @@
+#ifndef ORBIT_CORE_LINUX_TRACING_SESSION_H_
+#define ORBIT_CORE_LINUX_TRACING_SESSION_H_
+
+#include "ContextSwitch.h"
+#include "EventBuffer.h"
+#include "LinuxCallstackEvent.h"
+#include "ScopeTimer.h"
+
+#include "absl/synchronization/mutex.h"
+
+// This class stores information about tracing session
+// and provides thread-safe access and record functions.
+class LinuxTracingSession {
+ public:
+  LinuxTracingSession() = default;
+  LinuxTracingSession(const LinuxTracingSession&) = delete;
+  LinuxTracingSession& operator=(const LinuxTracingSession&) = delete;
+
+  void RecordContextSwitch(ContextSwitch&& context_switch);
+  void RecordTimer(Timer&& timer);
+  void RecordCallstack(LinuxCallstackEvent&& event);
+  void RecordHashedCallstack(CallstackEvent&& event);
+
+  // These move the content of corresponding buffer to
+  // the output vector. They return true if the buffer
+  // is not empty.
+  bool ReadAllContextSwitches(std::vector<ContextSwitch>* buffer);
+  bool ReadAllTimers(std::vector<Timer>* buffer);
+  bool ReadAllCallstacks(std::vector<LinuxCallstackEvent>* buffer);
+  bool ReadAllHashedCallstacks(std::vector<CallstackEvent>* buffer);
+
+  void Reset();
+
+ private:
+  // Buffering data to send large messages instead of small ones.
+  absl::Mutex context_switch_buffer_mutex_;
+  std::vector<ContextSwitch> context_switch_buffer_;
+
+  absl::Mutex timer_buffer_mutex_;
+  std::vector<Timer> timer_buffer_;
+
+  absl::Mutex callstack_buffer_mutex_;
+  std::vector<LinuxCallstackEvent> callstack_buffer_;
+
+  absl::Mutex hashed_callstack_buffer_mutex_;
+  std::vector<CallstackEvent> hashed_callstack_buffer_;
+};
+
+#endif  // ORBIT_CORE_LINUX_TRACING_SESSION_H_

--- a/OrbitCore/LinuxTracingSessionTests.cpp
+++ b/OrbitCore/LinuxTracingSessionTests.cpp
@@ -1,0 +1,363 @@
+#include "LinuxTracingSession.h"
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+TEST(LinuxTracingSession, Empty) {
+  LinuxTracingSession session;
+
+  std::vector<ContextSwitch> context_switches;
+  EXPECT_FALSE(session.ReadAllContextSwitches(&context_switches));
+  EXPECT_TRUE(context_switches.empty());
+
+  std::vector<Timer> timers;
+  EXPECT_FALSE(session.ReadAllTimers(&timers));
+  EXPECT_TRUE(timers.empty());
+
+  std::vector<LinuxCallstackEvent> callstacks;
+  EXPECT_FALSE(session.ReadAllCallstacks(&callstacks));
+  EXPECT_TRUE(callstacks.empty());
+
+  std::vector<CallstackEvent> hashed_callstacks;
+  EXPECT_FALSE(session.ReadAllHashedCallstacks(&hashed_callstacks));
+  EXPECT_TRUE(hashed_callstacks.empty());
+}
+
+TEST(LinuxTracingSession, ContextSwitches) {
+  LinuxTracingSession session;
+
+  {
+    ContextSwitch context_switch;
+    context_switch.m_ThreadId = 1;
+    context_switch.m_Type = ContextSwitch::Out;
+    context_switch.m_Time = 87;
+    context_switch.m_ProcessorIndex = 7;
+    context_switch.m_ProcessorNumber = 8;
+
+    session.RecordContextSwitch(std::move(context_switch));
+  }
+
+  {
+    ContextSwitch context_switch;
+
+    context_switch.m_ThreadId = 2;
+    context_switch.m_Type = ContextSwitch::In;
+    context_switch.m_Time = 78;
+    context_switch.m_ProcessorIndex = 17;
+    context_switch.m_ProcessorNumber = 18;
+
+    session.RecordContextSwitch(std::move(context_switch));
+  }
+
+  std::vector<ContextSwitch> context_switches;
+  EXPECT_TRUE(session.ReadAllContextSwitches(&context_switches));
+  EXPECT_FALSE(session.ReadAllContextSwitches(&context_switches));
+
+  EXPECT_EQ(context_switches.size(), 2);
+
+  EXPECT_EQ(context_switches[0].m_ThreadId, 1);
+  EXPECT_EQ(context_switches[0].m_Time, 87);
+  EXPECT_EQ(context_switches[0].m_ProcessorIndex, 7);
+  EXPECT_EQ(context_switches[0].m_ProcessorNumber, 8);
+
+  EXPECT_EQ(context_switches[1].m_ThreadId, 2);
+  EXPECT_EQ(context_switches[1].m_Time, 78);
+  EXPECT_EQ(context_switches[1].m_ProcessorIndex, 17);
+  EXPECT_EQ(context_switches[1].m_ProcessorNumber, 18);
+
+  {
+    ContextSwitch context_switch;
+
+    context_switch.m_ThreadId = 12;
+    context_switch.m_Type = ContextSwitch::Out;
+    context_switch.m_Time = 187;
+    context_switch.m_ProcessorIndex = 27;
+    context_switch.m_ProcessorNumber = 28;
+
+    session.RecordContextSwitch(std::move(context_switch));
+  }
+
+  // Check that the vector is reset, even if it was not empty
+  EXPECT_TRUE(session.ReadAllContextSwitches(&context_switches));
+  EXPECT_FALSE(session.ReadAllContextSwitches(&context_switches));
+
+  EXPECT_EQ(context_switches.size(), 1);
+
+  EXPECT_EQ(context_switches[0].m_ThreadId, 12);
+  EXPECT_EQ(context_switches[0].m_Time, 187);
+  EXPECT_EQ(context_switches[0].m_ProcessorIndex, 27);
+  EXPECT_EQ(context_switches[0].m_ProcessorNumber, 28);
+}
+
+TEST(LinuxTracingSession, Timers) {
+  LinuxTracingSession session;
+
+  {
+    Timer timer;
+    timer.m_TID = 1;
+    timer.m_Depth = 0;
+    timer.m_SessionID = 42;
+    timer.m_Type = Timer::CORE_ACTIVITY;
+    timer.m_Processor = 1;
+    timer.m_CallstackHash = 2;
+    timer.m_FunctionAddress = 3;
+    timer.m_UserData[0] = 7;
+    timer.m_UserData[1] = 77;
+    timer.m_Start = 800;
+    timer.m_End = 900;
+
+    session.RecordTimer(std::move(timer));
+  }
+
+  {
+    Timer timer;
+
+    timer.m_TID = 2;
+    timer.m_Depth = 0;
+    timer.m_SessionID = 42;
+    timer.m_Type = Timer::CORE_ACTIVITY;
+    timer.m_Processor = 3;
+    timer.m_CallstackHash = 4;
+    timer.m_FunctionAddress = 1;
+    timer.m_UserData[0] = 17;
+    timer.m_UserData[1] = 177;
+    timer.m_Start = 1800;
+    timer.m_End = 1900;
+
+    session.RecordTimer(std::move(timer));
+  }
+
+  std::vector<Timer> timers;
+  EXPECT_TRUE(session.ReadAllTimers(&timers));
+  EXPECT_FALSE(session.ReadAllTimers(&timers));
+
+  EXPECT_EQ(timers.size(), 2);
+
+  EXPECT_EQ(timers[0].m_TID, 1);
+  EXPECT_EQ(timers[0].m_Depth, 0);
+  EXPECT_EQ(timers[0].m_SessionID, 42);
+  EXPECT_EQ(timers[0].m_Type, Timer::CORE_ACTIVITY);
+  EXPECT_EQ(timers[0].m_Processor, 1);
+  EXPECT_EQ(timers[0].m_CallstackHash, 2);
+  EXPECT_EQ(timers[0].m_FunctionAddress, 3);
+  EXPECT_THAT(timers[0].m_UserData, testing::ElementsAre(7, 77));
+  EXPECT_EQ(timers[0].m_Start, 800);
+  EXPECT_EQ(timers[0].m_End, 900);
+
+  EXPECT_EQ(timers[1].m_TID, 2);
+  EXPECT_EQ(timers[1].m_Depth, 0);
+  EXPECT_EQ(timers[1].m_SessionID, 42);
+  EXPECT_EQ(timers[1].m_Type, Timer::CORE_ACTIVITY);
+  EXPECT_EQ(timers[1].m_Processor, 3);
+  EXPECT_EQ(timers[1].m_CallstackHash, 4);
+  EXPECT_EQ(timers[1].m_FunctionAddress, 1);
+  EXPECT_THAT(timers[1].m_UserData, testing::ElementsAre(17, 177));
+  EXPECT_EQ(timers[1].m_Start, 1800);
+  EXPECT_EQ(timers[1].m_End, 1900);
+
+  // Check that the vector is reset, even if it was not empty
+  {
+    Timer timer;
+    timer.m_TID = 12;
+    timer.m_Depth = 10;
+    timer.m_SessionID = 42;
+    timer.m_Type = Timer::CORE_ACTIVITY;
+    timer.m_Processor = 3;
+    timer.m_CallstackHash = 4;
+    timer.m_FunctionAddress = 1;
+    timer.m_UserData[0] = 7;
+    timer.m_UserData[1] = 77;
+    timer.m_Start = 1800;
+    timer.m_End = 1900;
+
+    session.RecordTimer(std::move(timer));
+  }
+
+  EXPECT_TRUE(session.ReadAllTimers(&timers));
+  EXPECT_EQ(timers.size(), 1);
+
+  EXPECT_FALSE(session.ReadAllTimers(&timers));
+  EXPECT_EQ(timers.size(), 1);
+
+  EXPECT_EQ(timers[0].m_TID, 12);
+  EXPECT_EQ(timers[0].m_Depth, 10);
+  EXPECT_EQ(timers[0].m_SessionID, 42);
+  EXPECT_EQ(timers[0].m_Type, Timer::CORE_ACTIVITY);
+  EXPECT_EQ(timers[0].m_Processor, 3);
+  EXPECT_EQ(timers[0].m_CallstackHash, 4);
+  EXPECT_EQ(timers[0].m_FunctionAddress, 1);
+  EXPECT_THAT(timers[0].m_UserData, testing::ElementsAre(7, 77));
+  EXPECT_EQ(timers[0].m_Start, 1800);
+  EXPECT_EQ(timers[0].m_End, 1900);
+}
+
+TEST(LinuxTracingSession, Callstacks) {
+  LinuxTracingSession session;
+
+  {
+    LinuxCallstackEvent event;
+    event.m_header = "test header 1";
+    event.m_time = 1;
+    event.m_CS.m_Hash = 0;
+    event.m_CS.m_Depth = 2;
+    event.m_CS.m_ThreadId = 5;
+    event.m_CS.m_Data.push_back(21);
+    event.m_CS.m_Data.push_back(22);
+
+    session.RecordCallstack(std::move(event));
+  }
+
+  {
+    LinuxCallstackEvent event;
+    event.m_header = "test header 2";
+    event.m_time = 2;
+    event.m_CS.m_Hash = 1;
+    event.m_CS.m_Depth = 12;
+    event.m_CS.m_ThreadId = 15;
+    event.m_CS.m_Data.push_back(121);
+    event.m_CS.m_Data.push_back(122);
+
+    session.RecordCallstack(std::move(event));
+  }
+
+  std::vector<LinuxCallstackEvent> callstacks;
+  EXPECT_TRUE(session.ReadAllCallstacks(&callstacks));
+  EXPECT_FALSE(session.ReadAllCallstacks(&callstacks));
+
+  EXPECT_EQ(callstacks.size(), 2);
+
+  EXPECT_EQ(callstacks[0].m_header, "test header 1");
+  EXPECT_EQ(callstacks[0].m_time, 1);
+  EXPECT_EQ(callstacks[0].m_CS.m_Hash, 0);
+  EXPECT_EQ(callstacks[0].m_CS.m_Depth, 2);
+  EXPECT_EQ(callstacks[0].m_CS.m_ThreadId, 5);
+  EXPECT_THAT(callstacks[0].m_CS.m_Data, testing::ElementsAre(21, 22));
+
+  EXPECT_EQ(callstacks[1].m_header, "test header 2");
+  EXPECT_EQ(callstacks[1].m_time, 2);
+  EXPECT_EQ(callstacks[1].m_CS.m_Hash, 1);
+  EXPECT_EQ(callstacks[1].m_CS.m_Depth, 12);
+  EXPECT_EQ(callstacks[1].m_CS.m_ThreadId, 15);
+  EXPECT_THAT(callstacks[1].m_CS.m_Data, testing::ElementsAre(121, 122));
+
+  {
+    LinuxCallstackEvent event;
+    event.m_header = "test header 3";
+    event.m_time = 3;
+    event.m_CS.m_Hash = 21;
+    event.m_CS.m_Depth = 22;
+    event.m_CS.m_ThreadId = 25;
+    event.m_CS.m_Data.push_back(221);
+    event.m_CS.m_Data.push_back(222);
+
+    session.RecordCallstack(std::move(event));
+  }
+  EXPECT_TRUE(session.ReadAllCallstacks(&callstacks));
+  EXPECT_EQ(callstacks.size(), 1);
+
+  EXPECT_FALSE(session.ReadAllCallstacks(&callstacks));
+  EXPECT_EQ(callstacks.size(), 1);
+
+  EXPECT_EQ(callstacks[0].m_header, "test header 3");
+  EXPECT_EQ(callstacks[0].m_time, 3);
+  EXPECT_EQ(callstacks[0].m_CS.m_Hash, 21);
+  EXPECT_EQ(callstacks[0].m_CS.m_Depth, 22);
+  EXPECT_EQ(callstacks[0].m_CS.m_ThreadId, 25);
+  EXPECT_THAT(callstacks[0].m_CS.m_Data, testing::ElementsAre(221, 222));
+}
+
+TEST(LinuxTracingSession, HashedCallstacks) {
+  LinuxTracingSession session;
+
+  session.RecordHashedCallstack(CallstackEvent(11, 12, 13));
+  session.RecordHashedCallstack(CallstackEvent(21, 22, 23));
+
+  std::vector<CallstackEvent> callstacks;
+  EXPECT_TRUE(session.ReadAllHashedCallstacks(&callstacks));
+  EXPECT_FALSE(session.ReadAllHashedCallstacks(&callstacks));
+
+  EXPECT_EQ(callstacks.size(), 2);
+
+  EXPECT_EQ(callstacks[0].m_Time, 11);
+  EXPECT_EQ(callstacks[0].m_Id, 12);
+  EXPECT_EQ(callstacks[0].m_TID, 13);
+
+  EXPECT_EQ(callstacks[1].m_Time, 21);
+  EXPECT_EQ(callstacks[1].m_Id, 22);
+  EXPECT_EQ(callstacks[1].m_TID, 23);
+
+  session.RecordHashedCallstack(CallstackEvent(31, 32, 33));
+
+  EXPECT_TRUE(session.ReadAllHashedCallstacks(&callstacks));
+  EXPECT_EQ(callstacks.size(), 1);
+
+  EXPECT_FALSE(session.ReadAllHashedCallstacks(&callstacks));
+  EXPECT_EQ(callstacks.size(), 1);
+
+  EXPECT_EQ(callstacks[0].m_Time, 31);
+  EXPECT_EQ(callstacks[0].m_Id, 32);
+  EXPECT_EQ(callstacks[0].m_TID, 33);
+}
+
+TEST(LinuxTracingSession, Reset) {
+  LinuxTracingSession session;
+
+  {
+    ContextSwitch context_switch;
+    context_switch.m_ThreadId = 1;
+    context_switch.m_Type = ContextSwitch::Out;
+    context_switch.m_Time = 87;
+    context_switch.m_ProcessorIndex = 7;
+    context_switch.m_ProcessorNumber = 8;
+
+    session.RecordContextSwitch(std::move(context_switch));
+  }
+
+  {
+    Timer timer;
+    timer.m_TID = 1;
+    timer.m_Depth = 0;
+    timer.m_SessionID = 42;
+    timer.m_Type = Timer::CORE_ACTIVITY;
+    timer.m_Processor = 1;
+    timer.m_CallstackHash = 2;
+    timer.m_FunctionAddress = 3;
+    timer.m_UserData[0] = 7;
+    timer.m_UserData[1] = 77;
+    timer.m_Start = 800;
+    timer.m_End = 900;
+
+    session.RecordTimer(std::move(timer));
+  }
+
+  {
+    LinuxCallstackEvent event;
+    event.m_header = "test header 3";
+    event.m_time = 3;
+    event.m_CS.m_Hash = 21;
+    event.m_CS.m_Depth = 22;
+    event.m_CS.m_ThreadId = 25;
+    event.m_CS.m_Data.push_back(221);
+    event.m_CS.m_Data.push_back(222);
+
+    session.RecordCallstack(std::move(event));
+  }
+
+  session.RecordHashedCallstack(CallstackEvent(11, 12, 13));
+
+  session.Reset();
+
+  std::vector<ContextSwitch> context_switches;
+  EXPECT_FALSE(session.ReadAllContextSwitches(&context_switches));
+
+  std::vector<Timer> timers;
+  EXPECT_FALSE(session.ReadAllTimers(&timers));
+
+  std::vector<LinuxCallstackEvent> callstacks;
+  EXPECT_FALSE(session.ReadAllCallstacks(&callstacks));
+
+  std::vector<CallstackEvent> hashed_callstacks;
+  EXPECT_FALSE(session.ReadAllHashedCallstacks(&hashed_callstacks));
+}

--- a/OrbitCore/ProcessUtils.cpp
+++ b/OrbitCore/ProcessUtils.cpp
@@ -284,9 +284,9 @@ void ProcessList::SetRemote(bool value) {
 }
 
 //-----------------------------------------------------------------------------
-std::shared_ptr<Process> ProcessList::GetProcess(uint32_t a_PID) {
+std::shared_ptr<Process> ProcessList::GetProcess(uint32_t pid) const {
   std::shared_ptr<Process> result = nullptr;
-  auto iter = m_ProcessesMap.find(a_PID);
+  auto iter = m_ProcessesMap.find(pid);
   if (iter != m_ProcessesMap.end()) result = iter->second;
   return result;
 }

--- a/OrbitCore/ProcessUtils.h
+++ b/OrbitCore/ProcessUtils.h
@@ -23,8 +23,9 @@ struct ProcessList {
   void SortByCPU();
   void UpdateCpuTimes();
   void SetRemote(bool a_Value);
-  bool Contains(uint32_t a_PID) const;
-  std::shared_ptr<Process> GetProcess(uint32_t a_PID);
+  bool Contains(uint32_t pid) const;
+  std::shared_ptr<Process> GetProcess(uint32_t pid) const;
+// TODO: make these private - do not access directly
   std::vector<std::shared_ptr<Process> > m_Processes;
   std::unordered_map<uint32_t, std::shared_ptr<Process> > m_ProcessesMap;
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -35,7 +35,6 @@ class OrbitApp : public CoreApp {
   std::string GetVersion();
   void CheckForUpdate();
   void CheckDebugger();
-  void SetupIntrospection();
 
   std::wstring GetCaptureFileName();
   std::string GetSessionFileName();
@@ -51,8 +50,6 @@ class OrbitApp : public CoreApp {
   void Inject(const std::string& file_name);
   virtual void StartCapture();
   virtual void StopCapture();
-  void StartRemoteCaptureBufferingThread() override;
-  void StopRemoteCaptureBufferingThread() override;
   void ToggleCapture();
   void OnDisconnect();
   void OnPdbLoaded();
@@ -80,8 +77,7 @@ class OrbitApp : public CoreApp {
   void ProcessContextSwitch(const ContextSwitch& a_ContextSwitch) override;
   void AddSymbol(uint64_t a_Address, const std::string& a_Module,
                  const std::string& a_Name) override;
-  void AddKeyAndString(uint64_t key, const std::string_view str) override;
-  void ProcessBufferedCaptureData();
+  void AddKeyAndString(uint64_t key, std::string_view str) override;
 
   int* GetScreenRes() { return m_ScreenRes; }
 
@@ -262,7 +258,6 @@ class OrbitApp : public CoreApp {
   std::queue<std::shared_ptr<struct Module> > m_ModulesToLoad;
   std::vector<std::string> m_PostInitArguments;
 
-  class EventTracer* m_EventTracer = nullptr;
   class Debugger* m_Debugger = nullptr;
   int m_NumTicks = 0;
 

--- a/OrbitGl/ModuleDataView.h
+++ b/OrbitGl/ModuleDataView.h
@@ -15,7 +15,6 @@ class ModulesDataView : public DataView {
   const std::vector<float>& GetColumnHeadersRatios() override;
   std::vector<std::wstring> GetContextMenu(int a_Index) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
-  ;
 
   void OnFilter(const std::wstring& a_Filter) override;
   void OnSort(int a_Column, bool a_Toggle = true) override;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -27,10 +27,7 @@
 #include "TimerManager.h"
 #include "Utils.h"
 #include "absl/strings/str_format.h"
-
-#ifdef _WIN32
 #include "EventTracer.h"
-#endif
 
 TimeGraph* GCurrentTimeGraph = nullptr;
 

--- a/OrbitService/CMakeLists.txt
+++ b/OrbitService/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 target_include_directories(OrbitService PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(OrbitService PRIVATE OrbitNoGl OrbitCore)
+target_link_libraries(OrbitService PRIVATE OrbitCore)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # Administrator privileges

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -2,28 +2,27 @@
 
 #include <iostream>
 
-#include "App.h"
+#include "Capture.h"
+#include "ConnectionManager.h"
 #include "Core.h"
-#include "DataView.h"
+#include "TimerManager.h"
+#include "TcpServer.h"
 
-//-----------------------------------------------------------------------------
 OrbitService::OrbitService() {
-  OrbitApp::Init();
-  GOrbitApp->SetHeadless(true);
-  GOrbitApp->SetCommandLineArguments({"headless"});
-  GOrbitApp->PostInit();
+  // TODO: these should be a private fields.
+  GTimerManager = std::make_unique<TimerManager>();
+  GTcpServer = new TcpServer();
+  Capture::Init();
 
-  DataView::Create(DataViewType::PROCESSES);
-  DataView::Create(DataViewType::MODULES);
+  GTcpServer->Start(Capture::GCapturePort);
+  ConnectionManager::Get().InitAsService();
 }
 
-//-----------------------------------------------------------------------------
-OrbitService::~OrbitService() {}
-
-//-----------------------------------------------------------------------------
 void OrbitService::Run() {
-  while (!m_ExitRequested) {
-    OrbitApp::MainTick();
+  while (!exit_requested_) {
+    GTcpServer->ProcessMainThreadCallbacks();
+    Capture::Update();
     Sleep(16);
   }
 }
+

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -1,12 +1,15 @@
 #pragma once
+
 #include <vector>
+
+#include "ProcessUtils.h"
+
 class OrbitService {
  public:
   OrbitService();
-  ~OrbitService();
-
   void Run();
 
  private:
-  bool m_ExitRequested = false;
+  // TODO: where is this set?
+  bool exit_requested_ = false;
 };


### PR DESCRIPTION
1. Introduce LinuxTracingSession which stores buffers on the server side to be sent to the client. The class implements thread-safe way to record and read information from buffers.

2. Move event recording and sending logic out of OrbitApp to ConnectionManager.

3. Stop using App class in OrbitService and stop linking against OrbitGl