### PR TITLE
Explicitly delete TcpEntity::Send(Message&, T*)

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -354,7 +354,7 @@ void Capture::SendDataTrackingInfo() {
     ArgTrackingHeader& header = msg.m_Header.m_ArgTrackingHeader;
     uint64_t address = func->GetVirtualAddress();
     header.m_Function = address;
-    header.m_NumArgs = (int)rule->m_TrackedVariables.size();
+    header.m_NumArgs = rule->m_TrackedVariables.size();
 
     // TODO: Argument tracking was hijacked by data tracking
     //       We should separate both concepts and revive argument
@@ -367,9 +367,7 @@ void Capture::SendDataTrackingInfo() {
       args.push_back(arg);
     }
 
-    msg.m_Size = (int)args.size() * sizeof(Argument);
-
-    GTcpServer->Send(msg, (void*)args.data());
+    GTcpServer->Send(msg, args);
   }
 }
 

--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -183,7 +183,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
         memcpy(buffer.data(), (void*)header.m_Address, a_Message.m_Size);
       }
 
-      Send(msg, (void*)buffer.data());
+      Send(msg, buffer);
       break;
     }
     case Msg_NewSession:

--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -146,8 +146,9 @@ void TimerManager::ConsumeTimers() {
 void TimerManager::SendTimers() {
   SetCurrentThreadName(L"OrbitSendTimers");
 
-  const size_t numTimers = 4096;
-  Timer Timers[numTimers];
+  constexpr size_t numTimers = 4096;
+
+  Timer timers[numTimers];
 
   while (!m_ExitRequested) {
     Message Msg(Msg_Timer);
@@ -157,12 +158,11 @@ void TimerManager::SendTimers() {
       m_ConditionVariable.wait();
     }
 
-    size_t numDequeued = m_LockFreeQueue.try_dequeue_bulk(Timers, numTimers);
+    size_t numDequeued = m_LockFreeQueue.try_dequeue_bulk(timers, numTimers);
     m_NumQueuedEntries -= (int)numDequeued;
     m_NumQueuedTimers -= (int)numDequeued;
-    Msg.m_Size = (int)numDequeued * sizeof(Timer);
 
-    GTcpClient->Send(Msg, (void*)Timers);
+    GTcpClient->Send(Msg, timers, numDequeued * sizeof(Timer));
 
     int numEntries = m_NumQueuedEntries;
     GTcpClient->Send(Msg_NumQueuedEntries, numEntries);

--- a/OrbitCore/Variable.cpp
+++ b/OrbitCore/Variable.cpp
@@ -30,8 +30,7 @@ void Variable::SendValue() {
     msg.m_Header.m_DataTransferHeader.m_Address =
         (ULONG64)GPdbDbg->GetHModule() + (ULONG64)m_Address;
     msg.m_Header.m_DataTransferHeader.m_Type = DataTransferHeader::Data;
-    msg.m_Size = m_Size;
-    GTcpServer->Send(msg, (void*)&m_Data);
+    GTcpServer->Send(msg, &m_Data, m_Size);
   }
 }
 


### PR DESCRIPTION
    Since we have tempalatazed method Send which works for any time
    but works differently it results in the situation when calling
    Send(Message, char*) leads to a pointer being sent instead of the
    content of the buffer. Something that can lead to several hours
    of debugging.
    
    Introduce Send(Message&, const void*, size_t) to replace deleted
    method.
    
    Test: build, run orbit.
