### PR TITLE
Reduce prints in the ring-buffer-reading thread

### DIFF
--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -78,9 +78,11 @@ class TracerThread {
   // Number of records to read consecutively from a perf_event_open ring buffer
   // before switching to another one.
   static constexpr int32_t ROUND_ROBIN_POLLING_BATCH_SIZE = 5;
+
   static constexpr uint64_t SMALL_RING_BUFFER_SIZE_KB = 256;
   static constexpr uint64_t BIG_RING_BUFFER_SIZE_KB = 2048;
-  static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 1000;
+
+  static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 100;
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 1000;
 
   pid_t pid_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -108,6 +108,8 @@ class TracerThread {
     uint64_t sched_switch_count = 0;
     uint64_t sample_count = 0;
     uint64_t uprobes_count = 0;
+    uint64_t lost_count = 0;
+    absl::flat_hash_map<PerfEventRingBuffer*, uint64_t> lost_count_per_buffer{};
   };
 
   EventStats stats_;


### PR DESCRIPTION
- Only (check whether to) print statistics when ring buffers empty
- Print lost events in a cumulative fashion
- Reduce IDLE_TIME_ON_EMPTY_RING_BUFFERS_US

This *greatly* reduces the number of events lost when instrumenting a frequently-called function.