### PR TITLE
All u(ret)probes on a single ring buffer per cpu

### DIFF
--- a/OrbitBase/CMakeLists.txt
+++ b/OrbitBase/CMakeLists.txt
@@ -2,17 +2,26 @@ cmake_minimum_required(VERSION 3.15)
 
 project(OrbitBase)
 
-add_library(OrbitBase INTERFACE)
+add_library(OrbitBase STATIC)
 
-target_compile_features(OrbitBase INTERFACE cxx_std_17)
+target_compile_options(OrbitBase PRIVATE ${STRICT_COMPILE_FLAGS})
 
-target_include_directories(OrbitBase INTERFACE
+target_compile_features(OrbitBase PUBLIC cxx_std_17)
+
+target_include_directories(OrbitBase PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_sources(OrbitBase INTERFACE
-        include/OrbitBase/Logging.h)
+target_include_directories(OrbitBase PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR})
 
-target_link_libraries(OrbitBase INTERFACE
+target_sources(OrbitBase PRIVATE
+        include/OrbitBase/Logging.h
+        include/OrbitBase/SafeStrerror.h)
+
+target_sources(OrbitBase PRIVATE
+        SafeStrerror.cpp)
+
+target_link_libraries(OrbitBase PUBLIC
         abseil::abseil
         std::filesystem)
 

--- a/OrbitBase/SafeStrerror.cpp
+++ b/OrbitBase/SafeStrerror.cpp
@@ -1,0 +1,14 @@
+#include <OrbitBase/SafeStrerror.h>
+
+#include <cstring>
+
+char* SafeStrerror(int errnum) {
+  constexpr size_t BUFLEN = 256;
+  thread_local char buf[BUFLEN];
+#ifdef _MSC_VER
+  strerror_s(buf, BUFLEN, errnum);
+  return buf;
+#else
+  return strerror_r(errnum, buf, BUFLEN);
+#endif
+}

--- a/OrbitBase/include/OrbitBase/SafeStrerror.h
+++ b/OrbitBase/include/OrbitBase/SafeStrerror.h
@@ -1,0 +1,10 @@
+#ifndef ORBIT_BASE_SAFE_STRERROR_H_
+#define ORBIT_BASE_SAFE_STRERROR_H_
+
+// strerror is not thread safe, as the implementation could reuse a buffer that
+// is not thread local and can be modified by a subsequent call to strerror or
+// strerror_l. This function instead uses a thread_local buffer with strerror_r
+// (or C11 strerror_s with MSVC).
+char* SafeStrerror(int errnum);
+
+#endif  // ORBIT_BASE_SAFE_STRERROR_H_

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -103,9 +103,9 @@ void LinuxTracingHandler::OnCallstack(
 
     if (!frame.GetFunctionName().empty() &&
         !target_process_->HasSymbol(address)) {
-      std::string symbol_name = absl::StrFormat(
-          "%s+%#x", llvm::demangle(frame.GetFunctionName()),
-          frame.GetFunctionOffset());
+      std::string symbol_name =
+          absl::StrFormat("%s+%#x", llvm::demangle(frame.GetFunctionName()),
+                          frame.GetFunctionOffset());
       std::shared_ptr<LinuxSymbol> symbol = std::make_shared<LinuxSymbol>();
       symbol->m_Module = frame.GetMapName();
       symbol->m_Name = symbol_name;
@@ -115,7 +115,6 @@ void LinuxTracingHandler::OnCallstack(
       std::string message_data = SerializeObjectBinary(*symbol);
       GTcpServer->Send(Msg_RemoteSymbol, message_data.c_str(),
                        message_data.size());
-
 
       target_process_->AddSymbol(address, symbol);
     }

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -17,8 +17,7 @@ class LinuxTracingHandler : LinuxTracing::TracerListener {
   static constexpr double DEFAULT_SAMPLING_FREQUENCY = 1000.0;
 
   LinuxTracingHandler(SamplingProfiler* sampling_profiler,
-                      LinuxTracingSession* session,
-                      Process* target_process,
+                      LinuxTracingSession* session, Process* target_process,
                       std::map<uint64_t, Function*>* selected_function_map,
                       uint64_t* num_context_switches)
       : sampling_profiler_(sampling_profiler),

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -50,6 +50,10 @@ class ContextSwitchPerfEvent : public PerfEvent {
   }
   bool IsSwitchIn() const { return !IsSwitchOut(); }
 
+  uint64_t GetStreamId() const {
+    return ring_buffer_record.sample_id.stream_id;
+  }
+
   uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 };
 
@@ -89,6 +93,10 @@ class SystemWideContextSwitchPerfEvent : public PerfEvent {
 
   bool IsSwitchIn() const { return !IsSwitchOut(); }
 
+  uint64_t GetStreamId() const {
+    return ring_buffer_record.sample_id.stream_id;
+  }
+
   uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 };
 
@@ -104,6 +112,12 @@ class ForkPerfEvent : public PerfEvent {
   pid_t GetParentPid() const { return ring_buffer_record.ppid; }
   pid_t GetTid() const { return ring_buffer_record.tid; }
   pid_t GetParentTid() const { return ring_buffer_record.ptid; }
+
+  uint64_t GetStreamId() const {
+    return ring_buffer_record.sample_id.stream_id;
+  }
+
+  uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 };
 
 class ExitPerfEvent : public PerfEvent {
@@ -118,6 +132,12 @@ class ExitPerfEvent : public PerfEvent {
   pid_t GetParentPid() const { return ring_buffer_record.ppid; }
   pid_t GetTid() const { return ring_buffer_record.tid; }
   pid_t GetParentTid() const { return ring_buffer_record.ptid; }
+
+  uint64_t GetStreamId() const {
+    return ring_buffer_record.sample_id.stream_id;
+  }
+
+  uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 };
 
 class LostPerfEvent : public PerfEvent {
@@ -131,6 +151,12 @@ class LostPerfEvent : public PerfEvent {
   void Accept(PerfEventVisitor* visitor) override;
 
   uint64_t GetNumLost() const { return ring_buffer_record.lost; }
+
+  uint64_t GetStreamId() const {
+    return ring_buffer_record.sample_id.stream_id;
+  }
+
+  uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 };
 
 struct __attribute__((__packed__)) dynamically_sized_perf_event_stack_sample {
@@ -145,7 +171,7 @@ struct __attribute__((__packed__)) dynamically_sized_perf_event_stack_sample {
   };
 
   perf_event_header header;
-  perf_event_sample_id_tid_time_cpu sample_id;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
   perf_event_sample_regs_user_all regs;
   dynamically_sized_perf_event_sample_stack_user stack;
 
@@ -168,6 +194,11 @@ class SamplePerfEvent : public PerfEvent {
 
   pid_t GetPid() const { return ring_buffer_record->sample_id.pid; }
   pid_t GetTid() const { return ring_buffer_record->sample_id.tid; }
+
+  uint64_t GetStreamId() const {
+    return ring_buffer_record->sample_id.stream_id;
+  }
+
   uint32_t GetCpu() const { return ring_buffer_record->sample_id.cpu; }
 
   std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
@@ -252,6 +283,11 @@ class UretprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
 
   pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
   pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
+
+  uint64_t GetStreamId() const {
+    return ring_buffer_record.sample_id.stream_id;
+  }
+
   uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 };
 

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -1,14 +1,12 @@
 #include "PerfEventOpen.h"
 
 #include <OrbitBase/Logging.h>
+#include <OrbitBase/SafeStrerror.h>
 #include <OrbitLinuxTracing/Function.h>
 #include <linux/perf_event.h>
 
 #include <cerrno>
-#include <cstring>
-#include <fstream>
 
-#include "absl/strings/numbers.h"
 #include "Utils.h"
 
 namespace LinuxTracing {
@@ -36,7 +34,7 @@ perf_event_attr generic_event_attr() {
 int generic_event_open(perf_event_attr* attr, pid_t pid, int32_t cpu) {
   int fd = perf_event_open(attr, pid, cpu, -1, 0);
   if (fd == -1) {
-    ERROR("perf_event_open: %s", strerror(errno));
+    ERROR("perf_event_open: %s", SafeStrerror(errno));
   }
   return fd;
 }
@@ -114,7 +112,7 @@ void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length) {
   void* mmap_ret =
       mmap(nullptr, mmap_length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (mmap_ret == reinterpret_cast<void*>(-1)) {
-    ERROR("mmap: %s", strerror(errno));
+    ERROR("mmap: %s", SafeStrerror(errno));
     return nullptr;
   }
 

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -28,7 +28,7 @@ perf_event_attr generic_event_attr() {
   pe.sample_stack_user = SAMPLE_STACK_USER_SIZE;
   pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
 
-  pe.sample_type = SAMPLE_TYPE_TID_TIME_CPU;
+  pe.sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
 
   return pe;
 }

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -12,6 +12,7 @@
 
 #include <cerrno>
 #include <cstdint>
+#include <cstring>
 #include <ctime>
 
 inline int perf_event_open(struct perf_event_attr* attr, pid_t pid, int cpu,
@@ -24,14 +25,14 @@ namespace LinuxTracing {
 inline void perf_event_reset(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_RESET, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_RESET: %d", ret);
+    ERROR("PERF_EVENT_IOC_RESET: %s", strerror(errno));
   }
 }
 
 inline void perf_event_enable(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_ENABLE, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_ENABLE: %d", ret);
+    ERROR("PERF_EVENT_IOC_ENABLE: %s", strerror(errno));
   }
 }
 
@@ -43,15 +44,25 @@ inline void perf_event_reset_and_enable(int file_descriptor) {
 inline void perf_event_disable(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_DISABLE, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_DISABLE: %d", ret);
+    ERROR("PERF_EVENT_IOC_DISABLE: %s", strerror(errno));
   }
 }
 
 inline void perf_event_redirect(int from_fd, int to_fd) {
   int ret = ioctl(from_fd, PERF_EVENT_IOC_SET_OUTPUT, to_fd);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_SET_OUTPUT: %d\n", ret);
+    ERROR("PERF_EVENT_IOC_SET_OUTPUT: %s", strerror(errno));
   }
+}
+
+inline uint64_t perf_event_get_id(int file_descriptor) {
+  uint64_t id;
+  int ret = ioctl(file_descriptor, PERF_EVENT_IOC_ID, &id);
+  if (ret != 0) {
+    ERROR("PERF_EVENT_IOC_ID: %s", strerror(errno));
+    return 0;
+  }
+  return id;
 }
 
 // This must be in sync with struct perf_event_sample_id_tid_time_streamid_cpu

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -54,10 +54,11 @@ inline void perf_event_redirect(int from_fd, int to_fd) {
   }
 }
 
-// This must be in sync with struct perf_event_sample_id_tid_time_cpu in
-// PerfEventRecords.h.
-static constexpr uint64_t SAMPLE_TYPE_TID_TIME_CPU =
-    PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CPU;
+// This must be in sync with struct perf_event_sample_id_tid_time_streamid_cpu
+// in PerfEventRecords.h.
+static constexpr uint64_t SAMPLE_TYPE_TID_TIME_STREAMID_CPU =
+    PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_STREAM_ID |
+    PERF_SAMPLE_CPU;
 
 // Sample all registers: they might all be necessary for DWARF-based stack
 // unwinding.

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -2,6 +2,7 @@
 #define ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_
 
 #include <OrbitBase/Logging.h>
+#include <OrbitBase/SafeStrerror.h>
 #include <asm/perf_regs.h>
 #include <asm/unistd.h>
 #include <linux/perf_event.h>
@@ -25,14 +26,14 @@ namespace LinuxTracing {
 inline void perf_event_reset(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_RESET, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_RESET: %s", strerror(errno));
+    ERROR("PERF_EVENT_IOC_RESET: %s", SafeStrerror(errno));
   }
 }
 
 inline void perf_event_enable(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_ENABLE, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_ENABLE: %s", strerror(errno));
+    ERROR("PERF_EVENT_IOC_ENABLE: %s", SafeStrerror(errno));
   }
 }
 
@@ -44,14 +45,14 @@ inline void perf_event_reset_and_enable(int file_descriptor) {
 inline void perf_event_disable(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_DISABLE, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_DISABLE: %s", strerror(errno));
+    ERROR("PERF_EVENT_IOC_DISABLE: %s", SafeStrerror(errno));
   }
 }
 
 inline void perf_event_redirect(int from_fd, int to_fd) {
   int ret = ioctl(from_fd, PERF_EVENT_IOC_SET_OUTPUT, to_fd);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_SET_OUTPUT: %s", strerror(errno));
+    ERROR("PERF_EVENT_IOC_SET_OUTPUT: %s", SafeStrerror(errno));
   }
 }
 
@@ -59,7 +60,7 @@ inline uint64_t perf_event_get_id(int file_descriptor) {
   uint64_t id;
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_ID, &id);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_ID: %s", strerror(errno));
+    ERROR("PERF_EVENT_IOC_ID: %s", SafeStrerror(errno));
     return 0;
   }
   return id;

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -5,25 +5,26 @@
 
 namespace LinuxTracing {
 
-// This struct must be in sync with the SAMPLE_TYPE_TID_TIME_CPU in
+// This struct must be in sync with the SAMPLE_TYPE_TID_TIME_STREAMID_CPU in
 // PerfEventOpen.h, as the bits set in perf_event_attr::sample_type determine
 // the fields this struct should have.
-struct __attribute__((__packed__)) perf_event_sample_id_tid_time_cpu {
-  uint32_t pid, tid; /* if PERF_SAMPLE_TID */
-  uint64_t time;     /* if PERF_SAMPLE_TIME */
-  uint32_t cpu, res; /* if PERF_SAMPLE_CPU */
+struct __attribute__((__packed__)) perf_event_sample_id_tid_time_streamid_cpu {
+  uint32_t pid, tid;  /* if PERF_SAMPLE_TID */
+  uint64_t time;      /* if PERF_SAMPLE_TIME */
+  uint64_t stream_id; /* if PERF_SAMPLE_STREAM_ID */
+  uint32_t cpu, res;  /* if PERF_SAMPLE_CPU */
 };
 
 struct __attribute__((__packed__)) perf_event_context_switch {
   perf_event_header header;
-  perf_event_sample_id_tid_time_cpu sample_id;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
 struct __attribute__((__packed__)) perf_event_context_switch_cpu_wide {
   perf_event_header header;
   uint32_t next_prev_pid;
   uint32_t next_prev_tid;
-  perf_event_sample_id_tid_time_cpu sample_id;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
 struct __attribute__((__packed__)) perf_event_fork_exit {
@@ -31,7 +32,7 @@ struct __attribute__((__packed__)) perf_event_fork_exit {
   uint32_t pid, ppid;
   uint32_t tid, ptid;
   uint64_t time;
-  perf_event_sample_id_tid_time_cpu sample_id;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
 // This struct must be in sync with the SAMPLE_REGS_USER_ALL in
@@ -68,12 +69,12 @@ struct __attribute__((__packed__)) perf_event_sample_stack_user {
 
 struct __attribute__((__packed__)) perf_event_empty_sample {
   perf_event_header header;
-  perf_event_sample_id_tid_time_cpu sample_id;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
 struct __attribute__((__packed__)) perf_event_stack_sample {
   perf_event_header header;
-  perf_event_sample_id_tid_time_cpu sample_id;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
   perf_event_sample_regs_user_all regs;
   perf_event_sample_stack_user stack;
 };
@@ -82,7 +83,7 @@ struct __attribute__((__packed__)) perf_event_lost {
   perf_event_header header;
   uint64_t id;
   uint64_t lost;
-  perf_event_sample_id_tid_time_cpu sample_id;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -1,10 +1,10 @@
 #include "PerfEventRingBuffer.h"
 
 #include <OrbitBase/Logging.h>
+#include <OrbitBase/SafeStrerror.h>
 #include <linux/perf_event.h>
 #include <sys/mman.h>
 
-#include <cstring>
 #include <utility>
 
 #include "PerfEventOpen.h"
@@ -94,7 +94,7 @@ PerfEventRingBuffer::~PerfEventRingBuffer() {
   if (metadata_page_ != nullptr) {
     int munmap_ret = munmap(metadata_page_, mmap_length_);
     if (munmap_ret != 0) {
-      ERROR("munmap: %s", strerror(errno));
+      ERROR("munmap: %s", SafeStrerror(errno));
     }
   }
 }

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -32,7 +32,8 @@ bool TracerThread::OpenRingBufferForGpuTracepoint(
 
   std::string buffer_name =
       absl::StrFormat("%s:%s_%i", tracepoint_category, tracepoint_name, cpu);
-  PerfEventRingBuffer ring_buffer{fd, GPU_TRACING_RING_BUFFER_SIZE_KB, buffer_name};
+  PerfEventRingBuffer ring_buffer{fd, GPU_TRACING_RING_BUFFER_SIZE_KB,
+                                  buffer_name};
   if (!ring_buffer.IsOpen()) {
     return false;
   }
@@ -58,29 +59,25 @@ bool TracerThread::OpenGpuTracepoints(const std::vector<int32_t>& cpus) {
   std::vector<PerfEventRingBuffer> ring_buffers;
   std::vector<int> gpu_tracing_fds;
   for (int32_t cpu : cpus) {
-    if (!OpenRingBufferForGpuTracepoint(
-            "amdgpu", "amdgpu_cs_ioctl", cpu,
-            &gpu_tracing_fds, &ring_buffers)) {
+    if (!OpenRingBufferForGpuTracepoint("amdgpu", "amdgpu_cs_ioctl", cpu,
+                                        &gpu_tracing_fds, &ring_buffers)) {
       CloseFileDescriptors(gpu_tracing_fds);
       return false;
     }
-    if (!OpenRingBufferForGpuTracepoint(
-            "amdgpu", "amdgpu_sched_run_job", cpu,
-            &gpu_tracing_fds, &ring_buffers)) {
+    if (!OpenRingBufferForGpuTracepoint("amdgpu", "amdgpu_sched_run_job", cpu,
+                                        &gpu_tracing_fds, &ring_buffers)) {
       CloseFileDescriptors(gpu_tracing_fds);
       return false;
     }
-    if (!OpenRingBufferForGpuTracepoint(
-            "dma_fence", "dma_fence_signaled", cpu,
-            &gpu_tracing_fds, &ring_buffers)) {
+    if (!OpenRingBufferForGpuTracepoint("dma_fence", "dma_fence_signaled", cpu,
+                                        &gpu_tracing_fds, &ring_buffers)) {
       CloseFileDescriptors(gpu_tracing_fds);
       return false;
     }
   }
 
-  // Since all tracepoints could successfully be opened, we can now
-  // commit all file descriptors and ring buffers to the TracerThread
-  // members.
+  // Since all tracepoints could successfully be opened, we can now commit all
+  // file descriptors and ring buffers to the TracerThread members.
   for (int fd : gpu_tracing_fds) {
     gpu_tracing_fds_.emplace(fd);
     tracing_fds_.push_back(fd);

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -32,7 +32,7 @@ bool TracerThread::OpenRingBufferForGpuTracepoint(
 
   std::string buffer_name =
       absl::StrFormat("%s:%s_%i", tracepoint_category, tracepoint_name, cpu);
-  PerfEventRingBuffer ring_buffer{fd, SMALL_RING_BUFFER_SIZE_KB, buffer_name};
+  PerfEventRingBuffer ring_buffer{fd, GPU_TRACING_RING_BUFFER_SIZE_KB, buffer_name};
   if (!ring_buffer.IsOpen()) {
     return false;
   }
@@ -124,7 +124,7 @@ void TracerThread::Run(
       int context_switch_fd = context_switch_event_open(-1, cpu);
       std::string buffer_name = absl::StrFormat("context_switch_%u", cpu);
       PerfEventRingBuffer context_switch_ring_buffer{
-          context_switch_fd, SMALL_RING_BUFFER_SIZE_KB, buffer_name};
+          context_switch_fd, CONTEXT_SWITCHES_RING_BUFFER_SIZE_KB, buffer_name};
       if (context_switch_ring_buffer.IsOpen()) {
         tracing_fds_.push_back(context_switch_fd);
         ring_buffers_.push_back(std::move(context_switch_ring_buffer));
@@ -223,8 +223,8 @@ void TracerThread::Run(
           int ring_buffer_fd = uprobes_fd;
           std::string buffer_name =
               absl::StrFormat("uprobes_uretprobes_%u", cpu);
-          ring_buffers_.emplace_back(ring_buffer_fd, BIG_RING_BUFFER_SIZE_KB,
-                                     buffer_name);
+          ring_buffers_.emplace_back(ring_buffer_fd,
+                                     UPROBES_RING_BUFFER_SIZE_KB, buffer_name);
           uprobes_ring_buffer_fds_per_cpu[cpu] = ring_buffer_fd;
           uprobes_fds_.emplace(ring_buffer_fd);
           // Must be called after the ring buffer has been opened.
@@ -238,7 +238,7 @@ void TracerThread::Run(
     int mmap_task_fd = mmap_task_event_open(-1, cpu);
     std::string buffer_name = absl::StrFormat("mmap_task_%u", cpu);
     PerfEventRingBuffer mmap_task_ring_buffer{
-        mmap_task_fd, BIG_RING_BUFFER_SIZE_KB, buffer_name};
+        mmap_task_fd, MMAP_TASK_RING_BUFFER_SIZE_KB, buffer_name};
     if (mmap_task_ring_buffer.IsOpen()) {
       tracing_fds_.push_back(mmap_task_fd);
       ring_buffers_.push_back(std::move(mmap_task_ring_buffer));
@@ -252,7 +252,7 @@ void TracerThread::Run(
       int sampling_fd = sample_event_open(sampling_period_ns_, -1, cpu);
       std::string buffer_name = absl::StrFormat("sampling_%u", cpu);
       PerfEventRingBuffer sampling_ring_buffer{
-          sampling_fd, BIG_RING_BUFFER_SIZE_KB, buffer_name};
+          sampling_fd, SAMPLING_RING_BUFFER_SIZE_KB, buffer_name};
       if (sampling_ring_buffer.IsOpen()) {
         tracing_fds_.push_back(sampling_fd);
         ring_buffers_.push_back(std::move(sampling_ring_buffer));

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -107,7 +107,8 @@ class TracerThread {
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;
-  absl::flat_hash_map<int, const Function*> uprobes_fds_to_function_;
+  absl::flat_hash_set<int> uprobes_fds_;
+  absl::flat_hash_map<uint64_t, const Function*> uprobes_ids_to_function_;
   absl::flat_hash_set<int> gpu_tracing_fds_;
 
   std::atomic<bool> stop_deferred_thread_ = false;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -88,8 +88,11 @@ class TracerThread {
   // before switching to another one.
   static constexpr int32_t ROUND_ROBIN_POLLING_BATCH_SIZE = 5;
 
-  static constexpr uint64_t SMALL_RING_BUFFER_SIZE_KB = 256;
-  static constexpr uint64_t BIG_RING_BUFFER_SIZE_KB = 2048;
+  static constexpr uint64_t CONTEXT_SWITCHES_RING_BUFFER_SIZE_KB = 256;
+  static constexpr uint64_t UPROBES_RING_BUFFER_SIZE_KB = 32 * 1024;
+  static constexpr uint64_t MMAP_TASK_RING_BUFFER_SIZE_KB = 64;
+  static constexpr uint64_t SAMPLING_RING_BUFFER_SIZE_KB = 2 * 1024;
+  static constexpr uint64_t GPU_TRACING_RING_BUFFER_SIZE_KB = 256;
 
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 100;
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 1000;

--- a/OrbitLinuxTracing/Utils.cpp
+++ b/OrbitLinuxTracing/Utils.cpp
@@ -6,9 +6,9 @@
 #include <fstream>
 #include <thread>
 
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/numbers.h"
 
 namespace LinuxTracing {
 


### PR DESCRIPTION
Use stream_id to associate uretprobes to their function (same for uprobes, but for them the IP could also have been used). For simplicity and consistency then, record stream_id for all events: the overhead is insignificant and it could always be useful in the future.