### PR TITLE
Removes the OrbitNoGl hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,11 +104,11 @@ endif()
 
 add_subdirectory(OrbitBase)
 add_subdirectory(OrbitCore)
-add_subdirectory(OrbitGl)
 add_subdirectory(OrbitService)
 add_subdirectory(OrbitTest)
 
 if(WITH_GUI)
+  add_subdirectory(OrbitGl)
   add_subdirectory(OrbitQt)
 endif()
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -20,21 +20,15 @@
 #include "Callstack.h"
 #include "Capture.h"
 #include "CaptureSerializer.h"
-#ifndef NOGL
 #include "CaptureWindow.h"
-#endif
 #include "ConnectionManager.h"
 #include "Debugger.h"
 #include "DiaManager.h"
 #include "EventTracer.h"
 #include "FunctionDataView.h"
-#ifndef NOGL
 #include "GlCanvas.h"
-#endif
 #include "GlobalDataView.h"
-#ifndef NOGL
 #include "ImGuiOrbit.h"
-#endif
 #include "Injection.h"
 #include "Introspection.h"
 #include "KeyAndString.h"
@@ -52,9 +46,7 @@
 #include "PluginManager.h"
 #include "PrintVar.h"
 #include "ProcessDataView.h"
-#ifndef NOGL
 #include "RuleEditor.h"
-#endif
 #include "SamplingProfiler.h"
 #include "SamplingReport.h"
 #include "ScopeTimer.h"
@@ -66,19 +58,15 @@
 #include "TcpClient.h"
 #include "TcpServer.h"
 #include "TestRemoteMessages.h"
-#ifndef NOGL
 #include "TextRenderer.h"
-#endif
 #include "TimerManager.h"
 #include "TypeDataView.h"
 #include "Utils.h"
 #include "Version.h"
 #include "curl/curl.h"
 
-#ifndef NOGL
 #define GLUT_DISABLE_ATEXIT_HACK
 #include "GL/freeglut.h"
-#endif
 
 #ifdef _WIN32
 #include "Disassembler.h"
@@ -187,9 +175,7 @@ void GLoadPdbAsync(const std::vector<std::string>& a_Modules) {
 void OrbitApp::ProcessTimer(const Timer& a_Timer,
                             const std::string& a_FunctionName) {
   CHECK(!ConnectionManager::Get().IsService());
-#ifndef NOGL
   GCurrentTimeGraph->ProcessTimer(a_Timer);
-#endif
   ++Capture::GFunctionCountMap[a_Timer.m_FunctionAddress];
 }
 
@@ -271,9 +257,7 @@ void OrbitApp::AddKeyAndString(uint64_t key, std::string_view str) {
 void OrbitApp::LoadSystrace(const std::string& a_FileName) {
   SystraceManager::Get().Clear();
   Capture::ClearCaptureData();
-#ifndef NOGL
   GCurrentTimeGraph->Clear();
-#endif
   if (Capture::GClearCaptureDataFunc) {
     Capture::GClearCaptureDataFunc();
   }
@@ -287,9 +271,7 @@ void OrbitApp::LoadSystrace(const std::string& a_FileName) {
   Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;
 
   for (const auto& timer : systrace->GetTimers()) {
-#ifndef NOGL
     GCurrentTimeGraph->ProcessTimer(timer);
-#endif
     ++Capture::GFunctionCountMap[timer.m_FunctionAddress];
   }
 
@@ -315,9 +297,7 @@ void OrbitApp::AppendSystrace(const std::string& a_FileName,
   Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;
 
   for (const auto& timer : systrace->GetTimers()) {
-#ifndef NOGL
     GCurrentTimeGraph->ProcessTimer(timer);
-#endif
     Capture::GFunctionCountMap[timer.m_FunctionAddress];
   }
 
@@ -368,9 +348,7 @@ bool OrbitApp::Init() {
 //-----------------------------------------------------------------------------
 void OrbitApp::PostInit() {
   string_manager_ = std::make_shared<StringManager>();
-#ifndef NOGL
   GCurrentTimeGraph->SetStringManager(string_manager_);
-#endif
 
   if (HasTcpServer()) {
     GTcpServer->AddCallback(Msg_MiniDump, [=](const Message& a_Msg) {
@@ -395,12 +373,10 @@ void OrbitApp::PostInit() {
   }
 
   if (!GOrbitApp->GetHeadless()) {
-#ifndef NOGL
     int my_argc = 0;
     glutInit(&my_argc, NULL);
     glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
     GetDesktopResolution(GOrbitApp->m_ScreenRes[0], GOrbitApp->m_ScreenRes[1]);
-#endif
   } else {
     ConnectionManager::Get().InitAsService();
   }
@@ -573,11 +549,7 @@ void OrbitApp::Disassemble(const std::string& a_FunctionName,
 //-----------------------------------------------------------------------------
 const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >*
 OrbitApp::GetRules() {
-#ifndef NOGL
   return &m_RuleEditor->GetRules();
-#else
-  return nullptr;
-#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -597,9 +569,7 @@ int OrbitApp::OnExit() {
   }
   delete GTcpServer;
   delete GOrbitApp;
-#ifndef NOGL
   Orbit_ImGui_Shutdown();
-#endif
   return 0;
 }
 
@@ -641,11 +611,9 @@ void OrbitApp::MainTick() {
   ++GOrbitApp->m_NumTicks;
 
   if (DoZoom) {
-#ifndef NOGL
     GCurrentTimeGraph->UpdateThreadIds();
     GOrbitApp->m_CaptureWindow->ZoomAll();
     GOrbitApp->NeedsRedraw();
-#endif
     DoZoom = false;
   }
 }
@@ -728,17 +696,13 @@ void OrbitApp::RegisterOutputLog(LogDataView* a_Log) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::RegisterRuleEditor(RuleEditor* a_RuleEditor) {
-#ifndef NOGL
   assert(m_RuleEditor == nullptr);
   m_RuleEditor = a_RuleEditor;
-#endif
 }
 
 //-----------------------------------------------------------------------------
 void OrbitApp::NeedsRedraw() {
-#ifndef NOGL
   m_CaptureWindow->NeedsUpdate();
-#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -765,10 +729,8 @@ void OrbitApp::AddSelectionReport(
 
 //-----------------------------------------------------------------------------
 void OrbitApp::GoToCode(DWORD64 a_Address) {
-#ifndef NOGL
   m_CaptureWindow->FindCode(a_Address);
   SendToUiNow(L"gotocode");
-#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -892,16 +854,13 @@ void OrbitApp::OnLoadSession(const std::string& file_name) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::OnSaveCapture(const std::string& file_name) {
-#ifndef NOGL
   CaptureSerializer ar;
   ar.m_TimeGraph = GCurrentTimeGraph;
   ar.Save(s2ws(file_name));
-#endif
 }
 
 //-----------------------------------------------------------------------------
 void OrbitApp::OnLoadCapture(const std::string& file_name) {
-#ifndef NOGL
   StopCapture();
   Capture::ClearCaptureData();
   GCurrentTimeGraph->Clear();
@@ -915,7 +874,6 @@ void OrbitApp::OnLoadCapture(const std::string& file_name) {
   m_ModulesDataView->SetProcess(Capture::GTargetProcess);
   StopCapture();
   DoZoom = true;  // TODO: remove global, review logic
-#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -1218,8 +1176,6 @@ void OrbitApp::OnRemoteModuleDebugInfo(const Message& a_Message) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::LaunchRuleEditor(Function* a_Function) {
-#ifndef NOGL
   m_RuleEditor->m_Window.Launch(a_Function);
   SendToUiNow(TEXT("RuleEditor"));
-#endif
 }

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -99,87 +99,23 @@ target_sources(
 
 target_include_directories(OrbitGl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(WITH_GUI)
-  target_link_libraries(
-    OrbitGl
-    PUBLIC OrbitCore
-           OrbitAsm
-           freetype-gl::freetype-gl
-           OpenGL::GLU
-           freetype::freetype
-           imgui::imgui
-           freeglut::freeglut
-           capstone::capstone
-           gte::gte
-           glew::glew)
-else()
-  # Don't build this target by default. It will not compile in a WITH_GUI=OFF
-  # setup.
-  set_target_properties(OrbitGl PROPERTIES EXCLUDE_FROM_ALL ON)
-endif()
+target_link_libraries(
+  OrbitGl
+  PUBLIC OrbitCore
+         OrbitAsm
+         freetype-gl::freetype-gl
+         OpenGL::GLU
+         freetype::freetype
+         imgui::imgui
+         freeglut::freeglut
+         capstone::capstone
+         gte::gte
+         glew::glew)
 
-if(TARGET OpenGL::GLX AND TARGET OpenGL::OpenGL AND WITH_GUI)
+if(TARGET OpenGL::GLX AND TARGET OpenGL::OpenGL)
   target_link_libraries(OrbitGl PUBLIC OpenGL::GLX)
 endif()
 
-if(NOT WIN32 AND WITH_GUI)
+if(NOT WIN32)
   target_link_libraries(OrbitGl PRIVATE X11::X11 X11::Xi X11::Xxf86vm)
 endif()
-
-
-# OrbitNoGl:
-# This target is a temporary solution to build OrbitService
-# without a dependency to OpenGl.
-# According to my tests, this does not affect the behaviour
-# of the collector, but I might be wrong.
-# I tested the following things:
-# - Starting the collector
-# - Connecting with the GUI
-# - Listing processes
-# - Sampling a process
-# - Load debug symbols
-# - Hook a function
-# - Verify that hooked function appears.
-add_library(OrbitNoGl STATIC)
-
-
-get_target_property(PRIV_SOURCES OrbitGl SOURCES)
-list(
-  REMOVE_ITEM
-  PRIV_SOURCES
-  shader.cpp
-  EventTrack.cpp
-  BlackBoard.cpp
-  CaptureSerializer.cpp
-  CaptureWindow.cpp
-  Card.cpp
-  PickingManager.cpp
-  GlUtils.cpp
-  ImmediateWindow.cpp
-  GlPanel.cpp
-  GlCanvas.cpp
-  HomeWindow.cpp
-  ImGuiOrbit.cpp
-  GlSlider.cpp
-  TextRenderer.cpp
-  TextBox.cpp
-  Track.cpp
-  RuleEditor.cpp
-  PluginCanvas.cpp
-  TimeGraph.cpp
-  ThreadTrack.cpp)
-target_sources(OrbitNoGl PRIVATE "${PRIV_SOURCES}")
-
-get_target_property(PUB_SOURCES OrbitGl INTERFACE_SOURCES)
-target_sources(OrbitNoGl PUBLIC "${PUB_SOURCES}")
-
-get_target_property(PUB_INC OrbitGl INCLUDE_DIRECTORIES)
-set_target_properties(OrbitNoGl PROPERTIES INCLUDE_DIRECTORIES "${PUB_INC}")
-
-get_target_property(INT_INC OrbitGl INTERFACE_INCLUDE_DIRECTORIES)
-set_target_properties(OrbitNoGl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                           "${INT_INC}")
-
-target_link_libraries(OrbitNoGl PUBLIC OrbitCore OrbitAsm capstone::capstone gte::gte)
-
-target_compile_definitions(OrbitNoGl PUBLIC NOGL)

--- a/OrbitGl/FunctionDataView.cpp
+++ b/OrbitGl/FunctionDataView.cpp
@@ -11,9 +11,7 @@
 #include "OrbitProcess.h"
 #include "OrbitType.h"
 #include "Pdb.h"
-#ifndef NOGL
 #include "RuleEditor.h"
-#endif
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This hack is not necessary anymore since ObitService does not depend on Orbit(No)Gl anymore.

Furthermore OrbitGl will only be built if the `WITH_GUI` option is enabled.

Test: Compiles for all target platforms.