### PR TITLE
Also use IP when detecting duplicate uprobes

### DIFF
--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -61,7 +61,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   static std::vector<CallstackFrame> CallstackFramesFromLibunwindstackFrames(
       const std::vector<unwindstack::FrameData>& libunwindstack_frames);
 
-  absl::flat_hash_map<pid_t, std::vector<uint64_t>> uprobe_sps_per_thread_{};
+  absl::flat_hash_map<pid_t, std::vector<std::pair<uint64_t, uint64_t>>>
+      uprobe_sps_ips_per_thread_{};
 };
 
 }  // namespace LinuxTracing


### PR DESCRIPTION
Build
```
int a = 0;

void functionB() {
  for(int i = 0; i < 1000000; ++i) {
    for (int j = 0; j < 100; ++j) {
       a += powf((float)j, 2.0f);
    }
  }
}

void functionA() {
  for(int i = 0; i < 1000000; ++i) {
    for (int j = 0; j < 100; ++j) {
       a += powf((float)j, 2.0f);
    }
  }
  functionB();
}

int main(int argc, char** argv) {
  while (true) {
    functionA();
    std::cout << a << std::endl;
  }
  return 0;
}
```
from b/150441366 with
```
g++ -O2
```

Without this fix, when instrumenting functionA and tail-called functionB,
functionB's uprobe event is now considered a duplicate.