### PR TITLE
Install libopengl0 during Linux bootstrapping

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -12,6 +12,7 @@ fi
 sudo apt-get update
 sudo apt-get install -y build-essential
 sudo apt-get install -y libglu1-mesa-dev mesa-common-dev libxmu-dev libxi-dev
+sudo apt-get install -y libopengl0
 sudo apt-get install -y qt5-default
 sudo apt-get install -y python3-pip
 


### PR DESCRIPTION
Some of the prebuilt binaries accidentially linked against libopengl.so on Linux.

A proper fix takes more time, so for now we just require libopengl0 to be installed.