### PR TITLE
Automatically detect cross compilation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -201,6 +201,15 @@ cmake ... # CMake from conan is now available
 
 There is also a `deactivate.{sh,bat,ps1}` which make your shell leave the virtual environment.
 
+### `ERROR: .../orbitprofiler/conanfile.py: 'options.ggp' doesn't exist` ?!?
+
+This message or a similar one indicates that your build profiles are
+outdated and need to be updated. You can either just call the bootstrap
+script again or you can manually update your conan config:
+```bash
+conan config install contrib/conan/configs/[windows,linux]
+```
+
 
 ## Cross-Compiling for GGP
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+
 class OrbitConan(ConanFile):
     name = "OrbitProfiler"
     version = "0.0.1"
@@ -9,7 +10,7 @@ class OrbitConan(ConanFile):
     url = "https://github.com/pierricgimmig/orbitprofiler.git"
     description = "C/C++ Performance Profiler"
     settings = "os", "compiler", "build_type", "arch"
-    generators = [ "cmake_find_package_multi", "cmake" ]
+    generators = ["cmake_find_package_multi", "cmake"]
     options = {"system_mesa": [True, False],
                "system_qt": [True, False], "with_gui": [True, False]}
     default_options = {"system_mesa": True,
@@ -32,7 +33,8 @@ class OrbitConan(ConanFile):
         self.requires("llvm_object/9.0.1@orbitdeps/stable")
         self.requires("openssl/1.1.1d@{}".format(self._orbit_channel))
         if self.settings.os != "Windows":
-            self.requires("libunwindstack/80a734f14@{}".format(self._orbit_channel))
+            self.requires(
+                "libunwindstack/80a734f14@{}".format(self._orbit_channel))
         self.requires("zlib/1.2.11@conan/stable")
 
         if self.settings.os == "Windows":
@@ -85,10 +87,12 @@ class OrbitConan(ConanFile):
         if self.options.with_gui:
             for path in self.deps_cpp_info["freetype-gl"].resdirs:
                 self.copy("Vera.ttf", src=path, dst="{}/fonts/".format(dest))
-                self.copy("Vera.ttf", src=path, dst="{}/fonts/".format("OrbitQt/"))
-                self.copy("v3f-t2f-c4f.*", src=path, dst="{}/shaders/".format(dest))
-                self.copy("v3f-t2f-c4f.*", src=path, dst="{}/shaders/".format("OrbitQt/"))
-
+                self.copy("Vera.ttf", src=path,
+                          dst="{}/fonts/".format("OrbitQt/"))
+                self.copy("v3f-t2f-c4f.*", src=path,
+                          dst="{}/shaders/".format(dest))
+                self.copy("v3f-t2f-c4f.*", src=path,
+                          dst="{}/shaders/".format("OrbitQt/"))
 
     def package(self):
         self.copy("*", src="bin/dri", dst="bin/dri", symlinks=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,9 +10,9 @@ class OrbitConan(ConanFile):
     description = "C/C++ Performance Profiler"
     settings = "os", "compiler", "build_type", "arch"
     generators = [ "cmake_find_package_multi", "cmake" ]
-    options = {"system_mesa": [True, False], "ggp": [True, False],
+    options = {"system_mesa": [True, False],
                "system_qt": [True, False], "with_gui": [True, False]}
-    default_options = {"system_mesa": True, "ggp": False,
+    default_options = {"system_mesa": True,
                        "system_qt": True, "with_gui": True}
     _orbit_channel = "orbitdeps/stable"
     exports_sources = "CMakeLists.txt", "Orbit*", "bin/*", "cmake/*", "external/*", "LICENSE"
@@ -75,7 +75,7 @@ class OrbitConan(ConanFile):
         cmake.definitions["WITH_GUI"] = "ON" if self.options.with_gui else "OFF"
         cmake.configure()
         cmake.build()
-        if not self.options.ggp:
+        if not tools.cross_building(self.settings, skip_x64_x86=True) and self.settings.get_safe("os.platform") != "GGP":
             cmake.test()
 
     def imports(self):

--- a/contrib/conan/configs/linux/profiles/ggp_debug
+++ b/contrib/conan/configs/linux/profiles/ggp_debug
@@ -10,7 +10,6 @@ compiler.libcxx=libc++
 build_type=Debug
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:ggp=True
 [build_requires]
 cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/contrib/conan/configs/linux/profiles/ggp_release
+++ b/contrib/conan/configs/linux/profiles/ggp_release
@@ -10,7 +10,6 @@ compiler.libcxx=libc++
 build_type=Release
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:ggp=True
 [build_requires]
 cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/contrib/conan/configs/linux/profiles/ggp_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/ggp_relwithdebinfo
@@ -10,7 +10,6 @@ compiler.libcxx=libc++
 build_type=RelWithDebInfo
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:ggp=True
 [build_requires]
 cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/contrib/conan/configs/windows/profiles/ggp_debug
+++ b/contrib/conan/configs/windows/profiles/ggp_debug
@@ -10,7 +10,6 @@ compiler.libcxx=libc++
 build_type=Debug
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:ggp=True
 [build_requires]
 cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/contrib/conan/configs/windows/profiles/ggp_release
+++ b/contrib/conan/configs/windows/profiles/ggp_release
@@ -10,7 +10,6 @@ compiler.libcxx=libc++
 build_type=Release
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:ggp=True
 [build_requires]
 cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/contrib/conan/configs/windows/profiles/ggp_relwithdebinfo
+++ b/contrib/conan/configs/windows/profiles/ggp_relwithdebinfo
@@ -10,7 +10,6 @@ compiler.libcxx=libc++
 build_type=RelWithDebInfo
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:ggp=True
 [build_requires]
 cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable


### PR DESCRIPTION
The conan build definition exposed an option `ggp? which was solely there to detect the cross compilation case.

This PR replaces that flag with the conan-internal cross-compilation detection mechanism.

**Note**: The PR requires every developer to update their conan profiles, either by running bootstrap again or by updating their profiles manually with this command:
```
conan config install contrib/conan/configs/linux # Linux
conan config install contrib/conan/configs/windows # Windows
```

I added a FAQ-entry describing this problem.