### PR TITLE
Also use CPU when detecting duplicate uprobes on thread migration

### DIFF
--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -61,8 +61,9 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   static std::vector<CallstackFrame> CallstackFramesFromLibunwindstackFrames(
       const std::vector<unwindstack::FrameData>& libunwindstack_frames);
 
-  absl::flat_hash_map<pid_t, std::vector<std::pair<uint64_t, uint64_t>>>
-      uprobe_sps_ips_per_thread_{};
+  absl::flat_hash_map<pid_t,
+                      std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>>
+      uprobe_sps_ips_cpus_per_thread_{};
 };
 
 }  // namespace LinuxTracing


### PR DESCRIPTION
Build
```
int a = 0;

void f(bool b) {
  for(int i = 0; i < 1000000; ++i) {
    for (int j = 0; j < 100; ++j) {
       a += powf((float)j, 2.0f);
    }
  }
  if (b) {
    f(false);
  }
}

int main(int argc, char** argv) {
  while (true) {
    f(true);
    std::cout << a << std::endl;
  }
  return 0;
}
```
with
```
g++ -O2
```

Without this, when instrumenting tail-recursion-optimized `f(bool)`,
the tail-recursive call is _always_ considered a duplicate.
**Note** that while this mitigates the problem, it doesn't solve it in the
general case: if thread is migrated after the first call and before the tail
call, the tail-recursive call is still incorrectly considered a duplicate.