### PR TITLE
Add core functionality in OrbitLinuxTracing for opening and tracing GPU driver events

### DIFF
--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -5,6 +5,9 @@
 
 #include <cerrno>
 #include <cstring>
+#include <fstream>
+
+#include "absl/strings/numbers.h"
 
 namespace LinuxTracing {
 namespace {
@@ -114,6 +117,34 @@ void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length) {
   }
 
   return mmap_ret;
+}
+
+int get_tracepoint_id(const char* tracepoint_category,
+                      const char* tracepoint_name) {
+  std::string filename =
+      absl::StrFormat("/sys/kernel/debug/tracing/events/%s/%s/id",
+                      tracepoint_category, tracepoint_name);
+  std::ifstream id_file{filename};
+  int tp_id = -1;
+  std::string line;
+  if (!std::getline(id_file, line) || !absl::SimpleAtoi(line, &tp_id)) {
+    ERROR("Error looking up tracepoint id for: %s:%s", tracepoint_category,
+          tracepoint_name);
+    return -1;
+  }
+  return tp_id;
+}
+
+int tracepoint_event_open(const char* tracepoint_category,
+                          const char* tracepoint_name, pid_t pid, int32_t cpu) {
+  int tp_id = get_tracepoint_id(tracepoint_category, tracepoint_name);
+  perf_event_attr pe = generic_event_attr();
+  pe.type = PERF_TYPE_TRACEPOINT;
+  pe.size = sizeof(struct perf_event_attr);
+  pe.config = tp_id;
+  pe.sample_type |= PERF_SAMPLE_RAW;
+
+  return generic_event_open(&pe, pid, cpu);
 }
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -106,6 +106,19 @@ int uretprobes_event_open(const char* module, uint64_t function_offset,
 // Create the ring buffer to use perf_event_open in sampled mode.
 void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length);
 
+// Looks up the tracepoint id for the given category (example: "sched")
+// and name (example: "sched_waking"). Returns the tracepoint id or
+// -1 in case of any errors.
+int get_tracepoint_id(const char* tracepoint_category,
+                      const char* tracepoint_name);
+
+// perf_event_open for tracepoint events. This opens a perf event for the
+// tracepoint given by the category (for example, "sched") and the name
+// (for example, "sched_waking"). Returns the file descriptor for the
+// perf event or -1 in case of any errors.
+int tracepoint_event_open(const char* tracepoint_category,
+                          const char* tracepoint_name, pid_t pid, int32_t cpu);
+
 }  // namespace LinuxTracing
 
 #endif  // ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -106,12 +106,6 @@ int uretprobes_event_open(const char* module, uint64_t function_offset,
 // Create the ring buffer to use perf_event_open in sampled mode.
 void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length);
 
-// Looks up the tracepoint id for the given category (example: "sched")
-// and name (example: "sched_waking"). Returns the tracepoint id or
-// -1 in case of any errors.
-int get_tracepoint_id(const char* tracepoint_category,
-                      const char* tracepoint_name);
-
 // perf_event_open for tracepoint events. This opens a perf event for the
 // tracepoint given by the category (for example, "sched") and the name
 // (for example, "sched_waking"). Returns the file descriptor for the

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -17,7 +17,7 @@ bool TracerThread::OpenRingBufferForGpuTracepoint(
     return false;
   }
   std::string buffer_name =
-      absl::StrFormat("%s:%s events", tracepoint_category, tracepoint_name);
+      absl::StrFormat("%s:%s_%i", tracepoint_category, tracepoint_name, cpu);
   PerfEventRingBuffer ring_buffer{fd, SMALL_RING_BUFFER_SIZE_KB, buffer_name};
   if (!ring_buffer.IsOpen()) {
     return false;
@@ -423,8 +423,8 @@ void TracerThread::ProcessMmapEvent(const perf_event_header& header,
 void TracerThread::ProcessSampleEvent(const perf_event_header& header,
                                       PerfEventRingBuffer* ring_buffer) {
   int fd = ring_buffer->GetFileDescriptor();
-  bool is_probe = uprobes_fds_to_function_.count(fd) > 0;
-  bool is_gpu_event = gpu_tracing_fds_.count(fd) > 0;
+  bool is_probe = uprobes_fds_to_function_.contains(fd);
+  bool is_gpu_event = gpu_tracing_fds_.contains(fd);
 
   // An event can never be a probe and a GPU event.
   assert(!(is_probe && is_gpu_event));
@@ -519,8 +519,8 @@ void TracerThread::ProcessDeferredEvents() {
 void TracerThread::Reset() {
   tracing_fds_.clear();
   ring_buffers_.clear();
-  gpu_tracing_fds_.clear();
   uprobes_fds_to_function_.clear();
+  gpu_tracing_fds_.clear();
   deferred_events_.clear();
   stop_deferred_thread_ = false;
 }

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -54,10 +54,12 @@ class TracerThread {
   void Run(const std::shared_ptr<std::atomic<bool>>& exit_requested);
 
  private:
-  bool OpenRingBufferForGpuTracepoint(const char* tracepoint_category,
-                                      const char* tracepoint_name, int32_t cpu);
+  bool OpenRingBufferForGpuTracepoint(
+      const char* tracepoint_category, const char* tracepoint_name, int32_t cpu,
+      std::vector<PerfEventRingBuffer>* ring_buffers);
 
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
+  void CleanupGpuTracepoints();
 
   void ProcessContextSwitchEvent(const perf_event_header& header,
                                  PerfEventRingBuffer* ring_buffer);
@@ -118,6 +120,7 @@ class TracerThread {
     uint64_t sched_switch_count = 0;
     uint64_t sample_count = 0;
     uint64_t uprobes_count = 0;
+    uint64_t gpu_events_count = 0;
     uint64_t lost_count = 0;
     absl::flat_hash_map<PerfEventRingBuffer*, uint64_t> lost_count_per_buffer{};
   };

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -100,7 +100,7 @@ class TracerThread {
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
   bool trace_instrumented_functions_ = true;
-  bool trace_gpu_driver_events_ = false;
+  bool trace_gpu_driver_events_ = true;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -20,6 +20,7 @@
 #include "PerfEventRingBuffer.h"
 #include "Utils.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 
 namespace LinuxTracing {
 
@@ -53,6 +54,11 @@ class TracerThread {
   void Run(const std::shared_ptr<std::atomic<bool>>& exit_requested);
 
  private:
+  bool OpenRingBufferForGpuTracepoint(const char* tracepoint_category,
+                                      const char* tracepoint_name, int32_t cpu);
+
+  bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
+
   void ProcessContextSwitchEvent(const perf_event_header& header,
                                  PerfEventRingBuffer* ring_buffer);
   void ProcessContextSwitchCpuWideEvent(const perf_event_header& header,
@@ -94,10 +100,12 @@ class TracerThread {
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
   bool trace_instrumented_functions_ = true;
+  bool trace_gpu_driver_events_ = false;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;
   absl::flat_hash_map<int, const Function*> uprobes_fds_to_function_;
+  absl::flat_hash_set<int> gpu_tracing_fds_;
 
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -56,6 +56,7 @@ class TracerThread {
  private:
   bool OpenRingBufferForGpuTracepoint(
       const char* tracepoint_category, const char* tracepoint_name, int32_t cpu,
+      std::vector<int>* gpu_tracing_fds,
       std::vector<PerfEventRingBuffer>* ring_buffers);
 
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
@@ -102,7 +103,7 @@ class TracerThread {
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
   bool trace_instrumented_functions_ = true;
-  bool trace_gpu_driver_events_ = true;
+  bool trace_gpu_driver_events_ = false;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;

--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -52,6 +52,12 @@ std::vector<int> GetCpusetCpus(pid_t pid);
 
 #endif
 
+// Looks up the tracepoint id for the given category (example: "sched")
+// and name (example: "sched_waking"). Returns the tracepoint id or
+// -1 in case of any errors.
+int GetTracepointId(const char* tracepoint_category,
+                    const char* tracepoint_name);
+
 }  // namespace LinuxTracing
 
 #endif  // ORBIT_LINUX_TRACING_UTILS_H_


### PR DESCRIPTION
This is the first of many PRs to merge GPU event tracing into the headless branch of ORBIT. The full end-to-end prototype is in the feature/gpu_trace branch. 

In detail, in this PR we
- add functions to open generic tracepoint events,
- add methods to TracerThread to open the GPU driver tracepoints we are interested in, and
- add GPU tracing in the main loop of TracerThread but keep it disabled for now.