### PR TITLE
Enable internal artifactory for kokoro builds

### DIFF
--- a/kokoro/conan/config/remotes.json
+++ b/kokoro/conan/config/remotes.json
@@ -1,0 +1,9 @@
+{
+ "remotes": [
+  {
+   "name": "artifactory",
+   "url": "http://artifactory.internal/artifactory/api/conan/conan",
+   "verify_ssl": false
+  }
+ ]
+}

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -20,6 +20,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" >/dev/null 2>&1 && pwd )"
 echo "Installing conan configuration (profiles, settings, etc.)..."
 conan config install $DIR/contrib/conan/configs/linux || exit $?
 
+# We replace the default remotes by our internal artifactory server
+# which acts as a secure source for prebuilt dependencies.
+cp -v $DIR/kokoro/conan/config/remotes.json ~/.conan/remotes.json
+
+export CONAN_REVISIONS_ENABLED=1
+
 cd ${KOKORO_ARTIFACTS_DIR}/github/orbitprofiler
 $DIR/build.sh clang7_release || exit $?
 conan package -bf $DIR/build_clang7_release/ $DIR

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -6,6 +6,13 @@ SET REPO_ROOT=%KOKORO_ARTIFACTS_DIR%\github\orbitprofiler
 conan config install %REPO_ROOT%\contrib\conan\configs\windows
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+REM We replace the default remotes by our internal artifactory server
+REM which acts as a secure source for prebuilt dependencies.
+copy /Y %REPO_ROOT%\kokoro\conan\config\remotes.json %USERPROFILE%\.conan\remotes.json
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+set CONAN_REVISIONS_ENABLED=1
+
 cd %KOKORO_ARTIFACTS_DIR%\github\orbitprofiler
 call build.bat msvc2019_release_x64
 IF ERRORLEVEL 1 exit %ERRORLEVEL%


### PR DESCRIPTION
The internal artifactory server serves prebuilt packages
for the kokoro-based CI system.

To not affect the developer workflow first the general conan configuration
is installed. Second the remotes.json is patched to point to the
internal artifactory server.

In theory this should speed up the builds as well.