### PR TITLE
Added debian packaging option to conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,22 +1,33 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
+import shutil
+from io import StringIO
 
 
 class OrbitConan(ConanFile):
     name = "OrbitProfiler"
-    version = "0.0.1"
     license = "BSD-2-Clause"
     url = "https://github.com/pierricgimmig/orbitprofiler.git"
     description = "C/C++ Performance Profiler"
     settings = "os", "compiler", "build_type", "arch"
     generators = ["cmake_find_package_multi", "cmake"]
     options = {"system_mesa": [True, False],
-               "system_qt": [True, False], "with_gui": [True, False]}
+               "system_qt": [True, False], "with_gui": [True, False],
+               "debian_packaging": [True, False]}
     default_options = {"system_mesa": True,
-                       "system_qt": True, "with_gui": True}
+                       "system_qt": True, "with_gui": True,
+                       "debian_packaging": False}
     _orbit_channel = "orbitdeps/stable"
     exports_sources = "CMakeLists.txt", "Orbit*", "bin/*", "cmake/*", "external/*", "LICENSE"
+
+    def _version(self):
+        if not self.version:
+            buf = StringIO()
+            self.run("git describe --always --dirty --tags", output=buf)
+            self.version = buf.getvalue().strip()[1:]
+
+        return self.version
 
     def requirements(self):
         if self.settings.os != "Windows" and self.options.with_gui and not self.options.system_qt and self.options.system_mesa:
@@ -53,6 +64,10 @@ class OrbitConan(ConanFile):
                 self.requires("qt/5.14.1@bincrafters/stable")
 
     def configure(self):
+        if self.options.debian_packaging and (self.settings.get_safe("os.platform") != "GGP" or tools.detected_os() != "Linux"):
+            raise ConanInvalidConfiguration(
+                "Debian packaging is only supported for GGP builds!")
+
         self.options["abseil"].cxx_standard = 17
         if self.options.with_gui:
             self.options["glew"].system_mesa = self.options.system_mesa
@@ -95,6 +110,37 @@ class OrbitConan(ConanFile):
                           dst="{}/shaders/".format("OrbitQt/"))
 
     def package(self):
+        if self.options.debian_packaging:
+            shutil.rmtree(self.package_folder)
+            self.copy("*.so*", src="bin/", dst="{}-{}/usr/lib/x86_64-linux-gnu/".format(
+                self.name, self._version()), symlinks=True)
+            self.copy("OrbitService", src="bin/",
+                      dst="{}-{}/usr/bin/".format(self.name, self._version()))
+            basedir = "{}/{}-{}".format(self.package_folder,
+                                        self.name, self._version())
+            os.makedirs("{}/DEBIAN".format(basedir), exist_ok=True)
+            tools.save("{}/DEBIAN/control".format(basedir), """Package: orbitprofiler
+Version: {}
+Section: development
+Priority: optional
+Architecture: amd64
+Maintainer: Google, Inc <orbitprofiler-eng@google.com>
+Description: Orbit is a C/C++ profiler for Windows, Linux and the Stadia Platform.
+Homepage: https://github.com/google/orbit
+Installed-Size: `du -ks usr/ | cut -f 1`
+""".format(self._version()))
+
+            tools.save("{}/DEBIAN/postinst".format(basedir), """
+#!/bin/bash
+# Setting the setuid-bit for OrbitService
+chmod -v 4775 /usr/bin/OrbitService
+""")
+
+            self.run("chmod +x {}/DEBIAN/postinst".format(basedir))
+            self.run("dpkg-deb -b --root-owner-group {}".format(basedir))
+            self.run("dpkg --contents {}.deb".format(basedir))
+            shutil.rmtree(basedir)
+
         self.copy("*", src="bin/dri", dst="bin/dri", symlinks=True)
         self.copy("*", src="bin/fonts", dst="bin/fonts", symlinks=True)
         self.copy("*", src="bin/shaders", dst="bin/shaders", symlinks=True)


### PR DESCRIPTION
Debian packaging will be needed for Stadia Instance deployment of OrbitService.

Debian packaging is optional (default off) and can be enabled via a conan build option.