### PR TITLE
Add kokoro configuration for GGP Linux cross compilation config

### DIFF
--- a/kokoro/gcp_ubuntu_ggp/continuous.cfg
+++ b/kokoro/gcp_ubuntu_ggp/continuous.cfg
@@ -1,0 +1,14 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/gcp_ubuntu/kokoro_build.sh"
+
+action {
+  define_artifacts {
+    regex: "**/testresults/*.xml"
+    regex: "github/orbitprofiler/build_ggp_relwithdebinfo/package/**"
+    strip_prefix: "github/orbitprofiler/build_ggp_relwithdebinfo/package"
+  }
+}

--- a/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+# Display commands being run.
+# WARNING: please only enable 'set -x' if necessary for debugging, and be very
+#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
+#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
+#  the credentials being printed in build logs.
+#  Additionally, recursive invocation with credentials as command-line
+#  parameters, will print the full command, with credentials, in the build logs.
+# set -x
+
+
+# Code under repo is checked out to ${KOKORO_ARTIFACTS_DIR}/github.
+# The final directory name in this path is determined by the scm name specified
+# in the job configuration.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" >/dev/null 2>&1 && pwd )"
+echo "Installing conan configuration (profiles, settings, etc.)..."
+conan config install $DIR/contrib/conan/configs/linux || exit $?
+
+# We replace the default remotes by our internal artifactory server
+# which acts as a secure source for prebuilt dependencies.
+cp -v $DIR/kokoro/conan/config/remotes.json ~/.conan/remotes.json
+
+export CONAN_REVISIONS_ENABLED=1
+profile=ggp_relwithdebinfo
+
+cd ${KOKORO_ARTIFACTS_DIR}/github/orbitprofiler
+conan install -u -pr $profile -if build_$profile/ --build outdated -o debian_packaging=True $DIR
+conan build -bf build_$profile/ $DIR
+conan package -bf $DIR/build_$profile/ $DIR
+
+# Uncomment the three lines below to print the external ip into the log and
+# keep the vm alive for two hours. This is useful to debug build failures that
+# can not be resolved by looking into sponge alone. Also comment out the
+# "set -e" at the top of this file (otherwise a failed build will exit this
+# script immediately).
+# external_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+# echo "INSTANCE_EXTERNAL_IP=${external_ip}"
+# sleep 7200;


### PR DESCRIPTION
**Note:** This is based on https://github.com/google-admin/orbit/pull/260 and I will rebase it as soon as pull/260 is merged.

This PR adds a kokoro build configuration for GGP Linux cross compilation builds with the GGP SDK.
It activates the debian packaging from pull/260. The only missing step now is the signing of the generated debian packages. As soon as that is done, deployment got a lot closer.