### PR TITLE
Adding Keystore support to the Kokoro GGP build

### DIFF
--- a/kokoro/gcp_ubuntu_ggp/continuous.cfg
+++ b/kokoro/gcp_ubuntu_ggp/continuous.cfg
@@ -5,6 +5,33 @@
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_ubuntu_ggp/kokoro_build.sh"
 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "SigningPrivateGpgKeyPassword"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "SigningPrivateGpg"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "SigningPublicGpg"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
 action {
   define_artifacts {
     regex: "**/testresults/*.xml"


### PR DESCRIPTION
For signing we need to fetch the GPG keys from Keystore in the Kokoro build.

This is the first step which makes the keys available during the GGP build.

PS: Appropriate reviewers are rare these days. It would be great if one of you could have a quick look.